### PR TITLE
Change class name User to ConfigCatUser

### DIFF
--- a/ConfigCat.xcodeproj/project.pbxproj
+++ b/ConfigCat.xcodeproj/project.pbxproj
@@ -70,7 +70,7 @@
 		3F1F2C8023E1218500AFA7D2 /* RefreshPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F880A9D207BF1B100087A6B /* RefreshPolicy.swift */; };
 		3F1F2C8123E1218500AFA7D2 /* Synced.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F880AA2207BF1B100087A6B /* Synced.swift */; };
 		3F1F2C8223E1218500AFA7D2 /* ManualPollingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F880AC3207BFA4A00087A6B /* ManualPollingPolicy.swift */; };
-		3F1F2C8423E1218500AFA7D2 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F9AF62169176A00F490CD /* User.swift */; };
+		3F1F2C8423E1218500AFA7D2 /* ConfigCatUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F9AF62169176A00F490CD /* ConfigCatUser.swift */; };
 		3F1F2C8523E1218500AFA7D2 /* RolloutEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F9AFB216922F000F490CD /* RolloutEvaluator.swift */; };
 		3F1F2C8623E1218600AFA7D2 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AEDBE8223876064008803E7 /* Config.swift */; };
 		3F1F2C8723E1218600AFA7D2 /* AsyncResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F880A9E207BF1B100087A6B /* AsyncResult.swift */; };
@@ -79,7 +79,7 @@
 		3F1F2C8A23E1218600AFA7D2 /* RefreshPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F880A9D207BF1B100087A6B /* RefreshPolicy.swift */; };
 		3F1F2C8B23E1218600AFA7D2 /* Synced.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F880AA2207BF1B100087A6B /* Synced.swift */; };
 		3F1F2C8C23E1218600AFA7D2 /* ManualPollingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F880AC3207BFA4A00087A6B /* ManualPollingPolicy.swift */; };
-		3F1F2C8E23E1218600AFA7D2 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F9AF62169176A00F490CD /* User.swift */; };
+		3F1F2C8E23E1218600AFA7D2 /* ConfigCatUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F9AF62169176A00F490CD /* ConfigCatUser.swift */; };
 		3F1F2C8F23E1218600AFA7D2 /* RolloutEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F9AFB216922F000F490CD /* RolloutEvaluator.swift */; };
 		3F1F2C9023E1218700AFA7D2 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AEDBE8223876064008803E7 /* Config.swift */; };
 		3F1F2C9123E1218700AFA7D2 /* AsyncResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F880A9E207BF1B100087A6B /* AsyncResult.swift */; };
@@ -88,7 +88,7 @@
 		3F1F2C9423E1218700AFA7D2 /* RefreshPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F880A9D207BF1B100087A6B /* RefreshPolicy.swift */; };
 		3F1F2C9523E1218700AFA7D2 /* Synced.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F880AA2207BF1B100087A6B /* Synced.swift */; };
 		3F1F2C9623E1218700AFA7D2 /* ManualPollingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F880AC3207BFA4A00087A6B /* ManualPollingPolicy.swift */; };
-		3F1F2C9823E1218700AFA7D2 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F9AF62169176A00F490CD /* User.swift */; };
+		3F1F2C9823E1218700AFA7D2 /* ConfigCatUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F9AF62169176A00F490CD /* ConfigCatUser.swift */; };
 		3F1F2C9923E1218700AFA7D2 /* RolloutEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F9AFB216922F000F490CD /* RolloutEvaluator.swift */; };
 		3F1F2C9A23E1227E00AFA7D2 /* Version+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A65478523A511E300EA53B8 /* Version+Codable.swift */; };
 		3F1F2C9B23E1227E00AFA7D2 /* Version+Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A65478323A511E300EA53B8 /* Version+Comparable.swift */; };
@@ -202,10 +202,10 @@
 		F10F787E2528950D0021F468 /* DataGovernanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10F787D2528950D0021F468 /* DataGovernanceTests.swift */; };
 		F10F787F2528950D0021F468 /* DataGovernanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10F787D2528950D0021F468 /* DataGovernanceTests.swift */; };
 		F10F78802528950D0021F468 /* DataGovernanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10F787D2528950D0021F468 /* DataGovernanceTests.swift */; };
-		F15F9AF72169176A00F490CD /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F9AF62169176A00F490CD /* User.swift */; };
-		F15F9AF82169176A00F490CD /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F9AF62169176A00F490CD /* User.swift */; };
-		F15F9AF92169176A00F490CD /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F9AF62169176A00F490CD /* User.swift */; };
-		F15F9AFA2169176A00F490CD /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F9AF62169176A00F490CD /* User.swift */; };
+		F15F9AF72169176A00F490CD /* ConfigCatUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F9AF62169176A00F490CD /* ConfigCatUser.swift */; };
+		F15F9AF82169176A00F490CD /* ConfigCatUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F9AF62169176A00F490CD /* ConfigCatUser.swift */; };
+		F15F9AF92169176A00F490CD /* ConfigCatUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F9AF62169176A00F490CD /* ConfigCatUser.swift */; };
+		F15F9AFA2169176A00F490CD /* ConfigCatUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F9AF62169176A00F490CD /* ConfigCatUser.swift */; };
 		F15F9AFC216922F000F490CD /* RolloutEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F9AFB216922F000F490CD /* RolloutEvaluator.swift */; };
 		F15F9AFD216922F000F490CD /* RolloutEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F9AFB216922F000F490CD /* RolloutEvaluator.swift */; };
 		F15F9AFE216922F000F490CD /* RolloutEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15F9AFB216922F000F490CD /* RolloutEvaluator.swift */; };
@@ -292,7 +292,7 @@
 		C45414AE24AF2BF2004E66E0 /* KeyValue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyValue.swift; sourceTree = "<group>"; };
 		C4D34D3A249B6F2900908D76 /* testmatrix_variationId.csv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = testmatrix_variationId.csv; sourceTree = "<group>"; };
 		F10F787D2528950D0021F468 /* DataGovernanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataGovernanceTests.swift; sourceTree = "<group>"; };
-		F15F9AF62169176A00F490CD /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
+		F15F9AF62169176A00F490CD /* ConfigCatUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigCatUser.swift; sourceTree = "<group>"; };
 		F15F9AFB216922F000F490CD /* RolloutEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RolloutEvaluator.swift; sourceTree = "<group>"; };
 		F15F9B122169738100F490CD /* testmatrix.csv */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = testmatrix.csv; sourceTree = "<group>"; };
 		F15F9B16216973B000F490CD /* RolloutIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RolloutIntegrationTests.swift; sourceTree = "<group>"; };
@@ -420,7 +420,7 @@
 				3F880AC3207BFA4A00087A6B /* ManualPollingPolicy.swift */,
 				3F880AC8207BFFA400087A6B /* ConfigCatClientProtocol.swift */,
 				3F880ACD207C072400087A6B /* ConfigCatClient.swift */,
-				F15F9AF62169176A00F490CD /* User.swift */,
+				F15F9AF62169176A00F490CD /* ConfigCatUser.swift */,
 				F15F9AFB216922F000F490CD /* RolloutEvaluator.swift */,
 				3F1F2C6023E103C600AFA7D2 /* PollingMode.swift */,
 				3F1F2C6523E10BF300AFA7D2 /* PollingModes.swift */,
@@ -774,7 +774,7 @@
 				3F880AAA207BF1B100087A6B /* Synced.swift in Sources */,
 				1A65479223A511E300EA53B8 /* Version+Codable.swift in Sources */,
 				3F880AC4207BFA4A00087A6B /* ManualPollingPolicy.swift in Sources */,
-				F15F9AF72169176A00F490CD /* User.swift in Sources */,
+				F15F9AF72169176A00F490CD /* ConfigCatUser.swift in Sources */,
 				1A65478623A511E300EA53B8 /* Version+Range.swift in Sources */,
 				3F880AC9207BFFA400087A6B /* ConfigCatClientProtocol.swift in Sources */,
 				3F880AA3207BF1B100087A6B /* ConfigParser.swift in Sources */,
@@ -818,7 +818,7 @@
 				3F4D40CA207EC20500BBAEC6 /* Mock.swift in Sources */,
 				3F36F53D2083DA3600949B8F /* LazyLoadingAsyncTests.swift in Sources */,
 				3F8EDF9820840FE900906339 /* ManualPollingTests.swift in Sources */,
-				3F1F2C8423E1218500AFA7D2 /* User.swift in Sources */,
+				3F1F2C8423E1218500AFA7D2 /* ConfigCatUser.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -842,7 +842,7 @@
 				3F880AB2207BF2A100087A6B /* Synced.swift in Sources */,
 				1A65479323A511E300EA53B8 /* Version+Codable.swift in Sources */,
 				3F880AC5207BFA4A00087A6B /* ManualPollingPolicy.swift in Sources */,
-				F15F9AF82169176A00F490CD /* User.swift in Sources */,
+				F15F9AF82169176A00F490CD /* ConfigCatUser.swift in Sources */,
 				1A65478723A511E300EA53B8 /* Version+Range.swift in Sources */,
 				3F880ACA207BFFA400087A6B /* ConfigCatClientProtocol.swift in Sources */,
 				3F880AAB207BF2A100087A6B /* AsyncResult.swift in Sources */,
@@ -886,7 +886,7 @@
 				3F4D40C9207EC20500BBAEC6 /* Mock.swift in Sources */,
 				3F36F53E2083DA3600949B8F /* LazyLoadingAsyncTests.swift in Sources */,
 				3F8EDF9920840FE900906339 /* ManualPollingTests.swift in Sources */,
-				3F1F2C8E23E1218600AFA7D2 /* User.swift in Sources */,
+				3F1F2C8E23E1218600AFA7D2 /* ConfigCatUser.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -910,7 +910,7 @@
 				3F880ABA207BF2A200087A6B /* Synced.swift in Sources */,
 				1A65479423A511E300EA53B8 /* Version+Codable.swift in Sources */,
 				3F880AC6207BFA4A00087A6B /* ManualPollingPolicy.swift in Sources */,
-				F15F9AF92169176A00F490CD /* User.swift in Sources */,
+				F15F9AF92169176A00F490CD /* ConfigCatUser.swift in Sources */,
 				1A65478823A511E300EA53B8 /* Version+Range.swift in Sources */,
 				3F880ACB207BFFA400087A6B /* ConfigCatClientProtocol.swift in Sources */,
 				3F880AB3207BF2A200087A6B /* AsyncResult.swift in Sources */,
@@ -954,7 +954,7 @@
 				3F4D40C8207EC20400BBAEC6 /* Mock.swift in Sources */,
 				3F36F53F2083DA3600949B8F /* LazyLoadingAsyncTests.swift in Sources */,
 				3F8EDF9A20840FE900906339 /* ManualPollingTests.swift in Sources */,
-				3F1F2C9823E1218700AFA7D2 /* User.swift in Sources */,
+				3F1F2C9823E1218700AFA7D2 /* ConfigCatUser.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -978,7 +978,7 @@
 				3F880AC2207BF2A300087A6B /* Synced.swift in Sources */,
 				1A65479523A511E300EA53B8 /* Version+Codable.swift in Sources */,
 				3F880AC7207BFA4A00087A6B /* ManualPollingPolicy.swift in Sources */,
-				F15F9AFA2169176A00F490CD /* User.swift in Sources */,
+				F15F9AFA2169176A00F490CD /* ConfigCatUser.swift in Sources */,
 				1A65478923A511E300EA53B8 /* Version+Range.swift in Sources */,
 				3F880ACC207BFFA400087A6B /* ConfigCatClientProtocol.swift in Sources */,
 				3F880ABB207BF2A300087A6B /* AsyncResult.swift in Sources */,

--- a/Sources/ConfigCatClient.swift
+++ b/Sources/ConfigCatClient.swift
@@ -73,7 +73,7 @@ public final class ConfigCatClient : NSObject, ConfigCatClientProtocol {
         self.maxWaitTimeForSyncCallsInSeconds = maxWaitTimeForSyncCallsInSeconds
     }
     
-    public func getValue<Value>(for key: String, defaultValue: Value, user: User?) -> Value {
+    public func getValue<Value>(for key: String, defaultValue: Value, user: ConfigCatUser?) -> Value {
         if key.isEmpty {
             assert(false, "key cannot be empty")
         }
@@ -94,7 +94,7 @@ public final class ConfigCatClient : NSObject, ConfigCatClientProtocol {
         return getValue(for: key, defaultValue: defaultValue, user: nil)
     }
     
-    public func getValueAsync<Value>(for key: String, defaultValue: Value, user: User?, completion: @escaping (Value) -> ()) {
+    public func getValueAsync<Value>(for key: String, defaultValue: Value, user: ConfigCatUser?, completion: @escaping (Value) -> ()) {
         if key.isEmpty {
             assert(false, "key cannot be empty")
         }
@@ -142,7 +142,7 @@ public final class ConfigCatClient : NSObject, ConfigCatClientProtocol {
         }
     }
 
-    @objc public func getVariationId(for key: String, defaultVariationId: String?, user: User? = nil) -> String? {
+    @objc public func getVariationId(for key: String, defaultVariationId: String?, user: ConfigCatUser? = nil) -> String? {
         if key.isEmpty {
             assert(false, "key cannot be empty")
         }
@@ -159,7 +159,7 @@ public final class ConfigCatClient : NSObject, ConfigCatClientProtocol {
         }
     }
 
-    @objc public func getVariationIdAsync(for key: String, defaultVariationId: String?, user: User? = nil, completion: @escaping (String?) -> ()) {
+    @objc public func getVariationIdAsync(for key: String, defaultVariationId: String?, user: ConfigCatUser? = nil, completion: @escaping (String?) -> ()) {
         if key.isEmpty {
             assert(false, "key cannot be empty")
         }
@@ -177,7 +177,7 @@ public final class ConfigCatClient : NSObject, ConfigCatClientProtocol {
         }
     }
 
-    @objc public func getAllVariationIds(user: User? = nil) -> [String] {
+    @objc public func getAllVariationIds(user: ConfigCatUser? = nil) -> [String] {
         do {
             let config = self.maxWaitTimeForSyncCallsInSeconds == 0
                     ? try self.refreshPolicy.getConfiguration().get()
@@ -190,7 +190,7 @@ public final class ConfigCatClient : NSObject, ConfigCatClientProtocol {
         }
     }
 
-    @objc public func getAllVariationIdsAsync(user: User? = nil, completion: @escaping ([String], Error?) -> ()) {
+    @objc public func getAllVariationIdsAsync(user: ConfigCatUser? = nil, completion: @escaping ([String], Error?) -> ()) {
         self.refreshPolicy.getConfiguration()
             .apply { config in
                 do {
@@ -246,12 +246,12 @@ public final class ConfigCatClient : NSObject, ConfigCatClientProtocol {
         self.refreshPolicy.refresh().accept(completion: completion)
     }
 
-    private func getDefaultConfig<Value>(for key: String, defaultValue: Value, user: User?) -> Value {
+    private func getDefaultConfig<Value>(for key: String, defaultValue: Value, user: ConfigCatUser?) -> Value {
         let latest = self.refreshPolicy.lastCachedConfiguration
         return latest.isEmpty ? defaultValue : self.deserializeJson(for: key, json: latest, defaultValue: defaultValue, user: user)
     }
     
-    private func deserializeJson<Value>(for key: String, json: String, defaultValue: Value, user: User?) -> Value {
+    private func deserializeJson<Value>(for key: String, json: String, defaultValue: Value, user: ConfigCatUser?) -> Value {
         do {
             return try ConfigCatClient.parser.parseValue(for: key, json: json, user: user)
         } catch {
@@ -280,19 +280,19 @@ extension ConfigCatClient {
         return getValue(for: key, defaultValue: defaultValue, user: nil)
     }
 
-    @objc public func getStringValue(for key: String, defaultValue: String, user: User?) -> String {
+    @objc public func getStringValue(for key: String, defaultValue: String, user: ConfigCatUser?) -> String {
         return getValue(for: key, defaultValue: defaultValue, user: user)
     }
-    @objc public func getIntValue(for key: String, defaultValue: Int, user: User?) -> Int {
+    @objc public func getIntValue(for key: String, defaultValue: Int, user: ConfigCatUser?) -> Int {
         return getValue(for: key, defaultValue: defaultValue, user: user)
     }
-    @objc public func getDoubleValue(for key: String, defaultValue: Double, user: User?) -> Double {
+    @objc public func getDoubleValue(for key: String, defaultValue: Double, user: ConfigCatUser?) -> Double {
         return getValue(for: key, defaultValue: defaultValue, user: user)
     }
-    @objc public func getBoolValue(for key: String, defaultValue: Bool, user: User?) -> Bool {
+    @objc public func getBoolValue(for key: String, defaultValue: Bool, user: ConfigCatUser?) -> Bool {
         return getValue(for: key, defaultValue: defaultValue, user: user)
     }
-    @objc public func getAnyValue(for key: String, defaultValue: Any, user: User?) -> Any {
+    @objc public func getAnyValue(for key: String, defaultValue: Any, user: ConfigCatUser?) -> Any {
         return getValue(for: key, defaultValue: defaultValue, user: user)
     }
 
@@ -312,19 +312,19 @@ extension ConfigCatClient {
         return getValueAsync(for: key, defaultValue: defaultValue, completion: completion)
     }
 
-    @objc public func getStringValueAsync(for key: String, defaultValue: String, user: User?, completion: @escaping (String) -> ()) {
+    @objc public func getStringValueAsync(for key: String, defaultValue: String, user: ConfigCatUser?, completion: @escaping (String) -> ()) {
         return getValueAsync(for: key, defaultValue: defaultValue, user: user, completion: completion)
     }
-    @objc public func getIntValueAsync(for key: String, defaultValue: Int, user: User?, completion: @escaping (Int) -> ()) {
+    @objc public func getIntValueAsync(for key: String, defaultValue: Int, user: ConfigCatUser?, completion: @escaping (Int) -> ()) {
         return getValueAsync(for: key, defaultValue: defaultValue, user: user, completion: completion)
     }
-    @objc public func getDoubleValueAsync(for key: String, defaultValue: Double, user: User?, completion: @escaping (Double) -> ()) {
+    @objc public func getDoubleValueAsync(for key: String, defaultValue: Double, user: ConfigCatUser?, completion: @escaping (Double) -> ()) {
         return getValueAsync(for: key, defaultValue: defaultValue, user: user, completion: completion)
     }
-    @objc public func getBoolValueAsync(for key: String, defaultValue: Bool, user: User?, completion: @escaping (Bool) -> ()) {
+    @objc public func getBoolValueAsync(for key: String, defaultValue: Bool, user: ConfigCatUser?, completion: @escaping (Bool) -> ()) {
         return getValueAsync(for: key, defaultValue: defaultValue, user: user, completion: completion)
     }
-    @objc public func getAnyValueAsync(for key: String, defaultValue: Any, user: User?, completion: @escaping (Any) -> ()) {
+    @objc public func getAnyValueAsync(for key: String, defaultValue: Any, user: ConfigCatUser?, completion: @escaping (Any) -> ()) {
         return getValueAsync(for: key, defaultValue: defaultValue, user: user, completion: completion)
     }
 }

--- a/Sources/ConfigCatClientProtocol.swift
+++ b/Sources/ConfigCatClientProtocol.swift
@@ -27,7 +27,7 @@ public protocol ConfigCatClientProtocol {
      - Parameter defaultValue: in case of any failure, this value will be returned.
      - Parameter user: the user object to identify the caller.
      */
-    func getValue<Value>(for key: String, defaultValue: Value, user: User?) -> Value
+    func getValue<Value>(for key: String, defaultValue: Value, user: ConfigCatUser?) -> Value
     
     /**
      Gets a value asynchronously as `Value` from the configuration identified by the given `key`.
@@ -37,7 +37,7 @@ public protocol ConfigCatClientProtocol {
      - Parameter user: the user object to identify the caller.
      - Parameter completion: the function which will be called when the configuration is successfully fetched.
      */
-    func getValueAsync<Value>(for key: String, defaultValue: Value, user: User?, completion: @escaping (Value) -> ())
+    func getValueAsync<Value>(for key: String, defaultValue: Value, user: ConfigCatUser?, completion: @escaping (Value) -> ())
     
     /// Gets all the setting keys.
     func getAllKeys() -> [String]
@@ -46,16 +46,16 @@ public protocol ConfigCatClientProtocol {
     func getAllKeysAsync(completion: @escaping ([String], Error?) -> ())
 
     /// Gets the Variation ID (analytics) of a feature flag or setting based on it's key.
-    func getVariationId(for key: String, defaultVariationId: String?, user: User?) -> String?
+    func getVariationId(for key: String, defaultVariationId: String?, user: ConfigCatUser?) -> String?
 
     /// Gets the Variation ID (analytics) of a feature flag or setting based on it's key asynchronously.
-    func getVariationIdAsync(for key: String, defaultVariationId: String?, user: User?, completion: @escaping (String?) -> ())
+    func getVariationIdAsync(for key: String, defaultVariationId: String?, user: ConfigCatUser?, completion: @escaping (String?) -> ())
 
     /// Gets the Variation IDs (analytics) of all feature flags or settings.
-    func getAllVariationIds(user: User?) -> [String]
+    func getAllVariationIds(user: ConfigCatUser?) -> [String]
 
     /// Gets the Variation IDs (analytics) of all feature flags or settings asynchronously.
-    func getAllVariationIdsAsync(user: User?, completion: @escaping ([String], Error?) -> ())
+    func getAllVariationIdsAsync(user: ConfigCatUser?, completion: @escaping ([String], Error?) -> ())
 
     /// Gets the key of a setting and it's value identified by the given Variation ID (analytics)
     func getKeyAndValue(for variationId: String) -> KeyValue?
@@ -80,19 +80,19 @@ public protocol ConfigCatClientProtocol {
     func getDoubleValue(for key: String, defaultValue: Double) -> Double
     func getBoolValue(for key: String, defaultValue: Bool) -> Bool
     func getAnyValue(for key: String, defaultValue: Any) -> Any
-    func getStringValue(for key: String, defaultValue: String, user: User?) -> String
-    func getIntValue(for key: String, defaultValue: Int, user: User?) -> Int
-    func getDoubleValue(for key: String, defaultValue: Double, user: User?) -> Double
-    func getBoolValue(for key: String, defaultValue: Bool, user: User?) -> Bool
-    func getAnyValue(for key: String, defaultValue: Any, user: User?) -> Any
+    func getStringValue(for key: String, defaultValue: String, user: ConfigCatUser?) -> String
+    func getIntValue(for key: String, defaultValue: Int, user: ConfigCatUser?) -> Int
+    func getDoubleValue(for key: String, defaultValue: Double, user: ConfigCatUser?) -> Double
+    func getBoolValue(for key: String, defaultValue: Bool, user: ConfigCatUser?) -> Bool
+    func getAnyValue(for key: String, defaultValue: Any, user: ConfigCatUser?) -> Any
     func getStringValueAsync(for key: String, defaultValue: String, completion: @escaping (String) -> ())
     func getIntValueAsync(for key: String, defaultValue: Int, completion: @escaping (Int) -> ())
     func getDoubleValueAsync(for key: String, defaultValue: Double, completion: @escaping (Double) -> ())
     func getBoolValueAsync(for key: String, defaultValue: Bool, completion: @escaping (Bool) -> ())
     func getAnyValueAsync(for key: String, defaultValue: Any, completion: @escaping (Any) -> ())
-    func getStringValueAsync(for key: String, defaultValue: String, user: User?, completion: @escaping (String) -> ())
-    func getIntValueAsync(for key: String, defaultValue: Int, user: User?, completion: @escaping (Int) -> ())
-    func getDoubleValueAsync(for key: String, defaultValue: Double, user: User?, completion: @escaping (Double) -> ())
-    func getBoolValueAsync(for key: String, defaultValue: Bool, user: User?, completion: @escaping (Bool) -> ())
-    func getAnyValueAsync(for key: String, defaultValue: Any, user: User?, completion: @escaping (Any) -> ())
+    func getStringValueAsync(for key: String, defaultValue: String, user: ConfigCatUser?, completion: @escaping (String) -> ())
+    func getIntValueAsync(for key: String, defaultValue: Int, user: ConfigCatUser?, completion: @escaping (Int) -> ())
+    func getDoubleValueAsync(for key: String, defaultValue: Double, user: ConfigCatUser?, completion: @escaping (Double) -> ())
+    func getBoolValueAsync(for key: String, defaultValue: Bool, user: ConfigCatUser?, completion: @escaping (Bool) -> ())
+    func getAnyValueAsync(for key: String, defaultValue: Any, user: ConfigCatUser?, completion: @escaping (Any) -> ())
 }

--- a/Sources/ConfigCatUser.swift
+++ b/Sources/ConfigCatUser.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// An object containing attributes to properly identify a given user for rollout evaluation.
-public final class User : NSObject {
+public final class ConfigCatUser : NSObject {
     fileprivate var attributes: [String: String]
     fileprivate(set) var identifier: String
     

--- a/Sources/ConfigParser.swift
+++ b/Sources/ConfigParser.swift
@@ -21,7 +21,7 @@ public final class ConfigParser {
      - Throws: `ParserError.invalidRequestedType` when the `Value` type is not supported.
      - Throws: `ParserError.parseFailure` when the parsing failed.
      */
-    public func parseValue<Value>(for key: String, json: String, user: User? = nil) throws -> Value {
+    public func parseValue<Value>(for key: String, json: String, user: ConfigCatUser? = nil) throws -> Value {
         if Value.self != String.self &&
             Value.self != String?.self &&
             Value.self != Int.self &&
@@ -74,7 +74,7 @@ public final class ConfigParser {
      - Parameter user: the user object to identify the caller.
      - Throws: `ParserError.parseFailure` when the parsing failed.
      */
-    public func parseVariationId(for key: String, json: String, user: User? = nil) throws -> String {
+    public func parseVariationId(for key: String, json: String, user: ConfigCatUser? = nil) throws -> String {
         if let jsonObject = try ConfigParser.parseEntries(json: json) {
             let (_, variationId): (Any?, String?) = self.evaluator.evaluate(json: jsonObject[key], key: key, user: user)
             if let variationId = variationId {
@@ -98,7 +98,7 @@ public final class ConfigParser {
      - Parameter user: the user object to identify the caller.
      - Throws: `ParserError.parseFailure` when the parsing failed.
      */
-    public func getAllVariationIds(json: String, user: User? = nil) throws -> [String] {
+    public func getAllVariationIds(json: String, user: ConfigCatUser? = nil) throws -> [String] {
         if let jsonObject = try ConfigParser.parseEntries(json: json) {
             var variationIds = [String]()
             for key in jsonObject.keys {

--- a/Sources/RolloutEvaluator.swift
+++ b/Sources/RolloutEvaluator.swift
@@ -25,7 +25,7 @@ class RolloutEvaluator {
         "IS NOT ONE OF (Sensitive)",
     ]
 
-    func evaluate<Value>(json: Any?, key: String, user: User?) -> (value: Value?, variationId: String?) {
+    func evaluate<Value>(json: Any?, key: String, user: ConfigCatUser?) -> (value: Value?, variationId: String?) {
         guard let json = json as? [String: Any] else {
             return (nil, nil)
         }

--- a/Tests/RolloutIntegrationTests.swift
+++ b/Tests/RolloutIntegrationTests.swift
@@ -87,7 +87,7 @@ class RolloutIntegrationTests: XCTestCase {
                 continue
             }
             
-            var user: User? = nil
+            var user: ConfigCatUser? = nil
             if testObjects[0] != "##null##" {
                 
                 var email = ""
@@ -108,7 +108,7 @@ class RolloutIntegrationTests: XCTestCase {
                     custom[customKey] = testObjects[3]
                 }
                 
-                user = User(identifier: identifier, email: email, country: country, custom: custom)
+                user = ConfigCatUser(identifier: identifier, email: email, country: country, custom: custom)
             }
             
             var i: Int = 0

--- a/samples/osx/configcatsample-objc/main.m
+++ b/samples/osx/configcatsample-objc/main.m
@@ -13,7 +13,7 @@ int main(int argc, const char * argv[]) {
                                                                  baseUrl:@""];
 
         // Creating a user object to identify your user (optional).
-        CCUser* userObject = [[CCUser alloc]initWithIdentifier:@"Some UserID"
+        ConfigCatUser* userObject = [[ConfigCatUser alloc]initWithIdentifier:@"Some UserID"
                                                      email:@"configcat@example.com"
                                                    country:@"CountryID"
                                                     custom:@{@"version": @"1.0.0"}];


### PR DESCRIPTION
Hi, @z4kn4fein 

I have proposing to renameing it to `ConfigCatUser` instead. I note that you have proposed to change to CCUser, but I think it might result in a higher chance of namespace conflict again. 

I am taking into consideration 

1.  My dependency on CometChatPro might also result in proposing for CCUser on their end. 

2. I noticed that you have adopted a fuller namespace and the use of `ConfigCat` as prefixes for some of the classes, i.e. `ConfigCatClientProtocol`, `ConfigCatClient` . 