### PR TITLE
Remove inlinable from Version inits

### DIFF
--- a/Version/Version.swift
+++ b/Version/Version.swift
@@ -36,7 +36,6 @@ public struct Version {
      - Note: Integers are made absolute since negative integers are not allowed, yet it is conventional Swift to take `Int` over `UInt` where possible.
      - Remark: This initializer variant provided for more readable code when initializing with static integers.
      */
-    @inlinable
     public init(_ major: Int, _ minor: Int, _ patch: Int, pre: [String] = [], build: [String] = []) {
         self.major = abs(major)
         self.minor = abs(minor)
@@ -55,7 +54,6 @@ public struct Version {
      - Note: Integers are made absolute since negative integers are not allowed, yet it is conventional Swift to take `Int` over `UInt` where possible.
      - Remark: This initializer variant provided when it would be more readable than the nameless variant.
      */
-    @inlinable
     public init(major: Int, minor: Int, patch: Int, prereleaseIdentifiers: [String] = [], buildMetadataIdentifiers: [String] = []) {
         self.init(major, minor, patch, pre: prereleaseIdentifiers, build: buildMetadataIdentifiers)
     }


### PR DESCRIPTION
Having @inlinable in these cases is causing build issues in our project in recent versions of Xcode, errors stating `'let' properties may not be initialized directly.`
This may be due to differences in newer Swift versions, but this is probably the simplest solution given inlinable really doesn't have much benefit in this case.