### PR TITLE
Added PRODUCT_BUNDLE_IDENTIFIER value for simulator SDKs.

### DIFF
--- a/ConfigCat.xcconfig
+++ b/ConfigCat.xcconfig
@@ -18,9 +18,12 @@ WATCHOS_DEPLOYMENT_TARGET = 3.0
 // the hyphen (`-`). This value is used as the `CFBundleIdentifier` in the `Info.plist`
 // of the built bundle.
 PRODUCT_BUNDLE_IDENTIFIER[sdk=appletvos*] = com.configcat.tvOS.client
+PRODUCT_BUNDLE_IDENTIFIER[sdk=appletvsimulator*] = com.configcat.tvOS.client
 PRODUCT_BUNDLE_IDENTIFIER[sdk=iphoneos*] = com.configcat.iOS.client
+PRODUCT_BUNDLE_IDENTIFIER[sdk=iphonesimulator*] = com.configcat.iOS.client
 PRODUCT_BUNDLE_IDENTIFIER[sdk=macosx*] = com.configcat.macOS.client
 PRODUCT_BUNDLE_IDENTIFIER[sdk=watchos*] = com.configcat.watchOS.client
+PRODUCT_BUNDLE_IDENTIFIER[sdk=watchsimulator*] = com.configcat.watchOS.client
 
 // Base SDK
 //


### PR DESCRIPTION
### Describe the purpose of your pull request

Adds missing config values for `PRODUCT_BUNDLE_IDENTIFIER` when build targeting simulator SDKs. They are currently set to use the same bundle identifier as builds using the device SDKs.

Another option could be to have a dynamic `PRODUCT_BUNDLE_IDENTIFIER` that uses the `PLATFORM_NAME` but I didn't want to be the one to change the bundle identifiers incase there's other things that depend on it.

```
PRODUCT_BUNDLE_IDENTIFIER = com.configcat.client.$(PLATFORM_NAME)
```

### Related issues (only if applicable)

- #18 

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
