### PR TITLE
Remove dynamic default, update swift version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,32 +11,25 @@ let package = Package(
         .macOS(.v10_12)
     ],
     products: [
-        .library(name: "ConfigCat", type: .dynamic, targets: ["ConfigCat"])
+        .library(name: "ConfigCat", targets: ["ConfigCat"]),
+        .library(name: "ConfigCatDynamic", type: .dynamic, targets: ["ConfigCat"])
     ],
     dependencies: [],
     targets: [
         .target(name: "Version",
-                dependencies: [],
-                exclude: ["LICENSE" , "version.txt"],
-                linkerSettings: [
-                    .linkedFramework("Foundation"),
-                ]),
+                exclude: ["LICENSE" , "version.txt"]),
         .target(name: "ConfigCat",
                 dependencies: ["Version"],
                 exclude: ["Resources/ConfigCat.h", "Resources/Info.plist"],
                 swiftSettings: [
                     .define("DEBUG", .when(configuration: .debug))
-                ],
-                linkerSettings: [
-                    .linkedFramework("Foundation"),
                 ]),
         .testTarget(name: "ConfigCatTests",
                     dependencies: ["ConfigCat"],
                     exclude: ["Resources/Info.plist"],
-                    resources: [
-                        .process("Resources")]
+                    resources: [.process("Resources")]
         )
         
     ],
-    swiftLanguageVersions: [.v4]
+    swiftLanguageVersions: [.v5]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,10 +11,8 @@ let package = Package(
         .macOS(.v10_12)
     ],
     products: [
-        .library(name: "ConfigCat", targets: ["ConfigCat"]),
-        .library(name: "ConfigCatDynamic", type: .dynamic, targets: ["ConfigCat"])
+      .library(name: "ConfigCat", targets: ["ConfigCat"])
     ],
-    dependencies: [],
     targets: [
         .target(name: "Version",
                 exclude: ["LICENSE" , "version.txt"]),


### PR DESCRIPTION
### Describe the purpose of your pull request

The package is currently forced as dynamic, which is strange behaviour for swift packages, and can break builds that use this package within another dynamic package.
Removing the type from the default product, and adding an explicit Dynamic product if anyone needs that explicitly.

Also removing some unnecessary linking, and updating swift version to 5 (the package definition itself already required swift 5, so this will have no effect)

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
