### PR TITLE
[chore] Remove unnecessary imports and public access level for members of internal types

### DIFF
--- a/Sources/ConfigCat/AutoPollingPolicy.swift
+++ b/Sources/ConfigCat/AutoPollingPolicy.swift
@@ -1,5 +1,4 @@
 import Foundation
-import os.log
 
 /// Describes a `RefreshPolicy` which polls the latest configuration over HTTP and updates the local cache repeatedly.
 final class AutoPollingPolicy : RefreshPolicy {
@@ -18,7 +17,7 @@ final class AutoPollingPolicy : RefreshPolicy {
      - Parameter sdkKey: the sdk key.          
      - Returns: A new `AutoPollingPolicy`.
      */
-    public convenience required init(cache: ConfigCache?, fetcher: ConfigFetcher, logger: Logger, configJsonCache: ConfigJsonCache, sdkKey: String) {
+    convenience required init(cache: ConfigCache?, fetcher: ConfigFetcher, logger: Logger, configJsonCache: ConfigJsonCache, sdkKey: String) {
         self.init(cache: cache, fetcher: fetcher, logger: logger, configJsonCache: configJsonCache, sdkKey: sdkKey, config: AutoPollingMode())
     }
     
@@ -31,12 +30,12 @@ final class AutoPollingPolicy : RefreshPolicy {
      - Parameter config: the configuration.
      - Returns: A new `AutoPollingPolicy`.
      */
-    public init(cache: ConfigCache?,
-                fetcher: ConfigFetcher,
-                logger: Logger,
-                configJsonCache: ConfigJsonCache,
-                sdkKey: String,
-                config: AutoPollingMode) {
+    init(cache: ConfigCache?,
+         fetcher: ConfigFetcher,
+         logger: Logger,
+         configJsonCache: ConfigJsonCache,
+         sdkKey: String,
+         config: AutoPollingMode) {
         self.autoPollIntervalInSeconds = config.autoPollIntervalInSeconds
         self.onConfigChanged = config.onConfigChanged
         super.init(cache: cache, fetcher: fetcher, logger: logger, configJsonCache: configJsonCache, sdkKey: sdkKey)
@@ -86,7 +85,7 @@ final class AutoPollingPolicy : RefreshPolicy {
         self.initTimer.cancel()
     }
     
-    public override func getConfiguration() -> AsyncResult<Config> {
+    override func getConfiguration() -> AsyncResult<Config> {
         if self.initResult.completed {
             return self.readCacheAsync()
         }

--- a/Sources/ConfigCat/ConfigFetcher.swift
+++ b/Sources/ConfigCat/ConfigFetcher.swift
@@ -1,4 +1,3 @@
-import os.log
 import Foundation
 
 enum Status {
@@ -23,14 +22,14 @@ struct FetchResponse {
      
      - Returns: the fetched config.
      */
-    public let config: Config?
+    let config: Config?
 
     /**
      Gets whether a new configuration value was fetched or not.
      
      - Returns: true if a new configuration value was fetched, otherwise false.
      */
-    public func isFetched() -> Bool {
+    func isFetched() -> Bool {
         return self.status == .fetched
     }
     
@@ -39,7 +38,7 @@ struct FetchResponse {
      
      - Returns: true if the fetch resulted a '304 Not Modified' code, otherwise false.
      */
-    public func isNotModified() -> Bool {
+    func isNotModified() -> Bool {
         return self.status == .notModified
     }
     
@@ -48,7 +47,7 @@ struct FetchResponse {
      
      - Returns: true if the fetch is failed, otherwise false.
      */
-    public func isFailed() -> Bool {
+    func isFailed() -> Bool {
         return self.status == .failure
     }
 }
@@ -70,7 +69,7 @@ class ConfigFetcher : NSObject {
     static let globalBaseUrl: String = "https://cdn-global.configcat.com"
     static let euOnlyBaseUrl: String = "https://cdn-eu.configcat.com"
 
-    public init(session: URLSession, logger: Logger, configJsonCache: ConfigJsonCache, sdkKey: String, mode: String,
+    init(session: URLSession, logger: Logger, configJsonCache: ConfigJsonCache, sdkKey: String, mode: String,
                 dataGovernance: DataGovernance, baseUrl: String = "") {
         self.log = logger
         self.configJsonCache = configJsonCache
@@ -86,12 +85,12 @@ class ConfigFetcher : NSObject {
         self.mode = mode
     }
 
-    public func isFetching() -> Bool {
+    func isFetching() -> Bool {
         guard let fetchingRequest = fetchingRequest else {return false}
         return !fetchingRequest.completed
     }
     
-    public func getConfiguration() -> AsyncResult<FetchResponse> {
+    func getConfiguration() -> AsyncResult<FetchResponse> {
         return self.executeFetch(executionCount: 2)
     }
     

--- a/Sources/ConfigCat/ConfigJsonCache.swift
+++ b/Sources/ConfigCat/ConfigJsonCache.swift
@@ -2,14 +2,14 @@ import Foundation
 import os.log
 
 class ConfigJsonCache {
-    public var config: Config = .empty
+    var config: Config = .empty
     private let log: Logger
 
-    public init(logger: Logger) {
+    init(logger: Logger) {
         self.log = logger
     }
 
-    public func getConfigFromJson(json: String) -> Config {
+    func getConfigFromJson(json: String) -> Config {
         if json.isEmpty {
             return .empty
         }

--- a/Sources/ConfigCat/LazyLoadingPolicy.swift
+++ b/Sources/ConfigCat/LazyLoadingPolicy.swift
@@ -1,6 +1,4 @@
 import Foundation
-import Dispatch
-import os.log
 
 /// Describes a `RefreshPolicy` which uses an expiring cache to maintain the internally stored configuration.
 final class LazyLoadingPolicy : RefreshPolicy {
@@ -20,7 +18,7 @@ final class LazyLoadingPolicy : RefreshPolicy {
      - Parameter sdkKey: the sdk key.
      - Returns: A new `LazyLoadingPolicy`.
      */
-    public convenience required init(cache: ConfigCache?, fetcher: ConfigFetcher, logger: Logger, configJsonCache: ConfigJsonCache, sdkKey: String) {
+    convenience required init(cache: ConfigCache?, fetcher: ConfigFetcher, logger: Logger, configJsonCache: ConfigJsonCache, sdkKey: String) {
         self.init(cache: cache, fetcher: fetcher, logger: logger, configJsonCache: configJsonCache, sdkKey: sdkKey, config: LazyLoadingMode())
     }
     
@@ -33,18 +31,18 @@ final class LazyLoadingPolicy : RefreshPolicy {
      - Parameter config: the configuration.
      - Returns: A new `LazyLoadingPolicy`.
      */
-    public init(cache: ConfigCache?,
-                fetcher: ConfigFetcher,
-                logger: Logger,
-                configJsonCache: ConfigJsonCache,
-                sdkKey: String,
-                config: LazyLoadingMode) {
+    init(cache: ConfigCache?,
+         fetcher: ConfigFetcher,
+         logger: Logger,
+         configJsonCache: ConfigJsonCache,
+         sdkKey: String,
+         config: LazyLoadingMode) {
         self.cacheRefreshIntervalInSeconds = config.cacheRefreshIntervalInSeconds
         self.useAsyncRefresh = config.useAsyncRefresh
         super.init(cache: cache, fetcher: fetcher, logger: logger, configJsonCache: configJsonCache, sdkKey: sdkKey)
     }
     
-    public override func getConfiguration() -> AsyncResult<Config> {
+    override func getConfiguration() -> AsyncResult<Config> {
         if self.lastRefreshTime.timeIntervalSinceNow < -self.cacheRefreshIntervalInSeconds {
             let initialized = self.initAsync.completed
             if initialized && !self.isFetching.testAndSet(expect: false, new: true) {

--- a/Sources/ConfigCat/Log.swift
+++ b/Sources/ConfigCat/Log.swift
@@ -11,27 +11,27 @@ import Foundation
 }
 
 class Logger {
-    public static let noLogger: Logger = Logger(level: .nolog)
+    static let noLogger: Logger = Logger(level: .nolog)
     fileprivate static let log: OSLog = OSLog(subsystem: "com.configcat", category: "main")
     fileprivate let level: LogLevel
     
-    public init(level: LogLevel) {
+    init(level: LogLevel) {
         self.level = level
     }
     
-    public func debug(message: StaticString, _ args: CVarArg...) {
+    func debug(message: StaticString, _ args: CVarArg...) {
         self.log(message: message, currentLevel: .debug, args: args)
     }
     
-    public func warning(message: StaticString, _ args: CVarArg...) {
+    func warning(message: StaticString, _ args: CVarArg...) {
         self.log(message: message, currentLevel: .warning, args: args)
     }
     
-    public func info(message: StaticString, _ args: CVarArg...) {
+    func info(message: StaticString, _ args: CVarArg...) {
         self.log(message: message, currentLevel: .info, args: args)
     }
     
-    public func error(message: StaticString, _ args: CVarArg...) {
+    func error(message: StaticString, _ args: CVarArg...) {
         self.log(message: message, currentLevel: .error, args: args)
     }
     

--- a/Sources/ConfigCat/ManualPollingPolicy.swift
+++ b/Sources/ConfigCat/ManualPollingPolicy.swift
@@ -10,7 +10,7 @@ final class ManualPollingPolicy : RefreshPolicy {
      - Parameter sdkKey: the sdk key.
      - Returns: A new `ManualPollingPolicy`.
      */
-    public required init(cache: ConfigCache?,
+    required init(cache: ConfigCache?,
                          fetcher: ConfigFetcher,
                          logger: Logger,
                          configJsonCache: ConfigJsonCache,
@@ -18,7 +18,7 @@ final class ManualPollingPolicy : RefreshPolicy {
         super.init(cache: cache, fetcher: fetcher, logger: logger, configJsonCache: configJsonCache, sdkKey: sdkKey)
     }
     
-    public override func getConfiguration() -> AsyncResult<Config> {
+    override func getConfiguration() -> AsyncResult<Config> {
         return AsyncResult<Config>.completed(result: self.readConfigCache())
     }
 }

--- a/Sources/ConfigCat/RefreshPolicy.swift
+++ b/Sources/ConfigCat/RefreshPolicy.swift
@@ -41,7 +41,7 @@ class RefreshPolicy : NSObject {
      - Parameter fetcher: the internal config fetcher instance.
      - Returns: A new `RefreshPolicy`.
      */
-    public required init(cache: ConfigCache?, fetcher: ConfigFetcher, logger: Logger, configJsonCache: ConfigJsonCache, sdkKey: String) {
+    required init(cache: ConfigCache?, fetcher: ConfigFetcher, logger: Logger, configJsonCache: ConfigJsonCache, sdkKey: String) {
         self.cache = cache
         self.fetcher = fetcher
         self.log = logger
@@ -56,12 +56,12 @@ class RefreshPolicy : NSObject {
      
      - Returns: the AsyncResult object which computes the configuration.
      */
-    open func getConfiguration() -> AsyncResult<Config> {
+    func getConfiguration() -> AsyncResult<Config> {
         assert(false, "Method must be overridden!")
         return AsyncResult(result: .empty)
     }
 
-    open func getSettings() -> AsyncResult<[String: Any]> {
+    func getSettings() -> AsyncResult<[String: Any]> {
         self.getConfiguration()
                 .apply(completion: { config in
                     return config.entries
@@ -73,7 +73,7 @@ class RefreshPolicy : NSObject {
      
      - Returns: the Async object which executes the refresh.
      */
-    public final func refresh() -> Async {
+    final func refresh() -> Async {
         return self.fetcher.getConfiguration().accept { response in
             if let config = response.config, response.isFetched() {
                 self.writeConfigCache(value: config)

--- a/Sources/ConfigCat/RolloutEvaluator.swift
+++ b/Sources/ConfigCat/RolloutEvaluator.swift
@@ -30,7 +30,7 @@ class RolloutEvaluator {
     fileprivate let log: Logger;
     
     
-    public init(logger: Logger) {
+    init(logger: Logger) {
         self.log = logger
     }
     


### PR DESCRIPTION
This PR removes public access level for members of types that are internal and thus not available outside of the module (thereby rendering `public` unnecessary). Some unnecessary imports have been removed as well.

- [X] I have covered the applied changes with automated tests. ConfigCatClientIntegrationTests is flaky when targeting Mac as platform. Tests run green on iPhone and Apple TV simulators. This seems to also be the case when on the master branch.
- [X] I have executed the full automated test set against my changes.
- [X] I have validated my changes against all supported platform versions.
- [X] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
