### PR TITLE
Deprecate ...Sync() methods

### DIFF
--- a/ConfigCat.podspec
+++ b/ConfigCat.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name          = "ConfigCat"
-  spec.version       = "9.3.0"
+  spec.version       = "9.4.0"
   spec.summary       = "ConfigCat Swift SDK"
   spec.swift_version = "4.2"
 

--- a/ConfigCat.xcconfig
+++ b/ConfigCat.xcconfig
@@ -47,4 +47,4 @@ SUPPORTED_PLATFORMS = macosx iphoneos iphonesimulator watchos watchsimulator app
 SWIFT_VERSION = 4.2
 
 // ConfigCat SDK version
-MARKETING_VERSION = 9.3.0
+MARKETING_VERSION = 9.4.0

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you want to use ConfigCat in a [SwiftPM](https://swift.org/package-manager/) 
 
 ``` swift
 dependencies: [
-  .package(url: "https://github.com/configcat/swift-sdk", from: "9.3.0")
+  .package(url: "https://github.com/configcat/swift-sdk", from: "9.4.0")
 ]
 ```
 

--- a/Sources/ConfigCat/Extensions.swift
+++ b/Sources/ConfigCat/Extensions.swift
@@ -156,7 +156,7 @@ extension ConfigCatClient {
     #endif
 
     // Synchronous extensions
-
+    @available(*, deprecated, message: "This method can produce thread priority inversion due to the usage of DispatchSemaphore for call synchronization. It will be removed in a future major version. Please use the asynchronous getValue() instead.")
     public func getValueSync<Value>(for key: String, defaultValue: Value, user: ConfigCatUser? = nil) -> Value {
         let semaphore = DispatchSemaphore(value: 0)
         var result: Value?
@@ -168,6 +168,7 @@ extension ConfigCatClient {
         return result ?? defaultValue
     }
 
+    @available(*, deprecated, message: "This method can produce thread priority inversion due to the usage of DispatchSemaphore for call synchronization. It will be removed in a future major version. Please use the asynchronous getValueDetails() instead.")
     public func getValueDetailsSync<Value>(for key: String, defaultValue: Value, user: ConfigCatUser? = nil) -> TypedEvaluationDetails<Value> {
         let semaphore = DispatchSemaphore(value: 0)
         var result: TypedEvaluationDetails<Value>?
@@ -179,6 +180,7 @@ extension ConfigCatClient {
         return result ?? TypedEvaluationDetails<Value>.fromError(key: key, value: defaultValue, error: String(format: "Could not get the evaluation details for '%@'.", key), user: user)
     }
 
+    @available(*, deprecated, message: "This method can produce thread priority inversion due to the usage of DispatchSemaphore for call synchronization. It will be removed in a future major version. Please use the asynchronous getAllValueDetails() instead.")
     @objc public func getAllValueDetailsSync(user: ConfigCatUser? = nil) -> [EvaluationDetails] {
         let semaphore = DispatchSemaphore(value: 0)
         var result = [EvaluationDetails]()
@@ -190,6 +192,7 @@ extension ConfigCatClient {
         return result
     }
 
+    @available(*, deprecated, message: "This method can produce thread priority inversion due to the usage of DispatchSemaphore for call synchronization. It will be removed in a future major version. Please use the asynchronous getAllKeys() instead.")
     @objc public func getAllKeysSync() -> [String] {
         let semaphore = DispatchSemaphore(value: 0)
         var result = [String]()
@@ -225,6 +228,7 @@ extension ConfigCatClient {
         return result
     }
 
+    @available(*, deprecated, message: "This method can produce thread priority inversion due to the usage of DispatchSemaphore for call synchronization. It will be removed in a future major version. Please use the asynchronous getKeyAndValue() instead.")
     @objc public func getKeyAndValueSync(for variationId: String) -> KeyValue? {
         let semaphore = DispatchSemaphore(value: 0)
         var result: KeyValue?
@@ -236,6 +240,7 @@ extension ConfigCatClient {
         return result
     }
 
+    @available(*, deprecated, message: "This method can produce thread priority inversion due to the usage of DispatchSemaphore for call synchronization. It will be removed in a future major version. Please use the asynchronous getAllValues() instead.")
     @objc public func getAllValuesSync(user: ConfigCatUser? = nil) -> [String: Any] {
         let semaphore = DispatchSemaphore(value: 0)
         var result = [String: Any]()
@@ -256,6 +261,7 @@ extension ConfigCatClient {
         semaphore.wait()
     }
 
+    @available(*, deprecated, message: "This method can produce thread priority inversion due to the usage of DispatchSemaphore for call synchronization. It will be removed in a future major version. Please use the asynchronous forceRefresh() instead.")
     @discardableResult
     @objc public func forceRefreshSync() -> RefreshResult {
         let semaphore = DispatchSemaphore(value: 0)
@@ -268,38 +274,47 @@ extension ConfigCatClient {
         return refreshResult ?? RefreshResult(success: false)
     }
 
+    @available(*, deprecated, message: "This method can produce thread priority inversion due to the usage of DispatchSemaphore for call synchronization. It will be removed in a future major version. Please use the asynchronous getStringValue() instead.")
     @objc public func getStringValueSync(for key: String, defaultValue: String, user: ConfigCatUser?) -> String {
         getValueSync(for: key, defaultValue: defaultValue, user: user)
     }
 
+    @available(*, deprecated, message: "This method can produce thread priority inversion due to the usage of DispatchSemaphore for call synchronization. It will be removed in a future major version. Please use the asynchronous getIntValue() instead.")
     @objc public func getIntValueSync(for key: String, defaultValue: Int, user: ConfigCatUser?) -> Int {
         getValueSync(for: key, defaultValue: defaultValue, user: user)
     }
 
+    @available(*, deprecated, message: "This method can produce thread priority inversion due to the usage of DispatchSemaphore for call synchronization. It will be removed in a future major version. Please use the asynchronous getDoubleValue() instead.")
     @objc public func getDoubleValueSync(for key: String, defaultValue: Double, user: ConfigCatUser?) -> Double {
         getValueSync(for: key, defaultValue: defaultValue, user: user)
     }
 
+    @available(*, deprecated, message: "This method can produce thread priority inversion due to the usage of DispatchSemaphore for call synchronization. It will be removed in a future major version. Please use the asynchronous getBoolValue() instead.")
     @objc public func getBoolValueSync(for key: String, defaultValue: Bool, user: ConfigCatUser?) -> Bool {
         getValueSync(for: key, defaultValue: defaultValue, user: user)
     }
 
+    @available(*, deprecated, message: "This method can produce thread priority inversion due to the usage of DispatchSemaphore for call synchronization. It will be removed in a future major version. Please use the asynchronous getAnyValue() instead.")
     @objc public func getAnyValueSync(for key: String, defaultValue: Any, user: ConfigCatUser?) -> Any {
         getValueSync(for: key, defaultValue: defaultValue, user: user)
     }
 
+    @available(*, deprecated, message: "This method can produce thread priority inversion due to the usage of DispatchSemaphore for call synchronization. It will be removed in a future major version. Please use the asynchronous getStringValueDetails() instead.")
     @objc public func getStringValueDetailsSync(for key: String, defaultValue: String, user: ConfigCatUser?) -> StringEvaluationDetails {
         getValueDetailsSync(for: key, defaultValue: defaultValue, user: user).toStringDetails()
     }
 
+    @available(*, deprecated, message: "This method can produce thread priority inversion due to the usage of DispatchSemaphore for call synchronization. It will be removed in a future major version. Please use the asynchronous getIntValueDetails() instead.")
     @objc public func getIntValueDetailsSync(for key: String, defaultValue: Int, user: ConfigCatUser?) -> IntEvaluationDetails {
         getValueDetailsSync(for: key, defaultValue: defaultValue, user: user).toIntDetails()
     }
 
+    @available(*, deprecated, message: "This method can produce thread priority inversion due to the usage of DispatchSemaphore for call synchronization. It will be removed in a future major version. Please use the asynchronous getDoubleValueDetails() instead.")
     @objc public func getDoubleValueDetailsSync(for key: String, defaultValue: Double, user: ConfigCatUser?) -> DoubleEvaluationDetails {
         getValueDetailsSync(for: key, defaultValue: defaultValue, user: user).toDoubleDetails()
     }
 
+    @available(*, deprecated, message: "This method can produce thread priority inversion due to the usage of DispatchSemaphore for call synchronization. It will be removed in a future major version. Please use the asynchronous getBoolValueDetails() instead.")
     @objc public func getBoolValueDetailsSync(for key: String, defaultValue: Bool, user: ConfigCatUser?) -> BoolEvaluationDetails {
         getValueDetailsSync(for: key, defaultValue: defaultValue, user: user).toBoolDetails()
     }

--- a/Sources/ConfigCat/Utils.swift
+++ b/Sources/ConfigCat/Utils.swift
@@ -38,7 +38,7 @@ extension Date {
 }
 
 class Constants {
-    static let version: String = "9.3.0"
+    static let version: String = "9.4.0"
     static let configJsonName: String = "config_v5"
     static let globalBaseUrl: String = "https://cdn-global.configcat.com"
     static let euOnlyBaseUrl: String = "https://cdn-eu.configcat.com"


### PR DESCRIPTION
### Describe the purpose of your pull request

In this PR, I've deprecated each `...Sync()` method. The synchronization with `DispatchSemaphore` is considered dangerous due to thread priority inversion. More details [here](https://developer.apple.com/documentation/xcode/diagnosing-performance-issues-early). 
As there is no official way to do this in a safe way we'll remove these methods in the next major version.

### Related issues (only if applicable)

#35 

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
