### PR TITLE
Fixing a cache read issue

### DIFF
--- a/ConfigCat.podspec
+++ b/ConfigCat.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name          = "ConfigCat"
-  spec.version       = "11.0.0"
+  spec.version       = "11.0.1"
   spec.summary       = "ConfigCat Swift SDK"
   spec.swift_version = "5.0"
 

--- a/ConfigCat.xcconfig
+++ b/ConfigCat.xcconfig
@@ -38,4 +38,4 @@ SUPPORTED_PLATFORMS = macosx iphoneos iphonesimulator watchos watchsimulator app
 SWIFT_VERSION = 5.0
 
 // ConfigCat SDK version
-MARKETING_VERSION = 11.0.0
+MARKETING_VERSION = 11.0.1

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The following device platform versions are supported:
 
   ``` swift
   dependencies: [
-    .package(url: "https://github.com/configcat/swift-sdk", from: "11.0.0")
+    .package(url: "https://github.com/configcat/swift-sdk", from: "11.0.1")
   ]
   ```
 

--- a/Sources/ConfigCat/ConfigService.swift
+++ b/Sources/ConfigCat/ConfigService.swift
@@ -193,7 +193,7 @@ class ConfigService {
         defer { mutex.unlock() }
         // Sync up with the cache and use it when it's not expired.
         let entry = readCache()
-        if cachedEntry.isEmpty && entry != cachedEntry {
+        if !entry.isEmpty && entry != cachedEntry {
             cachedEntry = entry
             hooks.invokeOnConfigChanged(config: entry.config)
         }

--- a/Sources/ConfigCat/Utils.swift
+++ b/Sources/ConfigCat/Utils.swift
@@ -47,7 +47,7 @@ extension Equatable {
 }
 
 class Constants {
-    static let version: String = "11.0.0"
+    static let version: String = "11.0.1"
     static let configJsonName: String = "config_v6.json"
     static let configJsonCacheVersion: String = "v2"
     static let globalBaseUrl: String = "https://cdn-global.configcat.com"

--- a/Tests/ConfigCatTests/CacheTest.swift
+++ b/Tests/ConfigCatTests/CacheTest.swift
@@ -25,4 +25,31 @@ class CacheTests: XCTestCase {
         XCTAssertEqual(testJson, fromCache.configJson)
         XCTAssertEqual("test-etag", fromCache.eTag)
     }
+    
+    #if compiler(>=5.5) && canImport(_Concurrency)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    func testCacheTTLRespectsExternalCache() async {
+        let testJson = "{\"f\":{\"testKey\":{\"t\":1,\"v\":{\"s\":\"%@\"}}}}"
+        let engine = MockEngine()
+        engine.enqueueResponse(response: Response(body: String(format: testJson, "remote"), statusCode: 200))
+        
+        let entry = try! ConfigEntry.fromConfigJson(json: String(format: testJson, "local"), eTag: "test-etag", fetchTime: Date()).get()
+        let cache = SingleValueCache(initValue: entry.serialize())
+        let client = ConfigCatClient(sdkKey: randomSdkKey(), pollingMode: PollingModes.lazyLoad(cacheRefreshIntervalInSeconds: 1), logger: NoLogger(), httpEngine: engine, configCache: cache)
+        var val = await client.getValue(for: "testKey", defaultValue: "")
+        
+        XCTAssertEqual("local", val)
+        XCTAssertEqual(0, engine.requests.count)
+        
+        sleep(2)
+        
+        let entry2 = try! ConfigEntry.fromConfigJson(json: String(format: testJson, "local2"), eTag: "test-etag2", fetchTime: Date()).get()
+        try! cache.write(for: "", value: entry2.serialize())
+        
+        val = await client.getValue(for: "testKey", defaultValue: "")
+        
+        XCTAssertEqual("local2", val)
+        XCTAssertEqual(0, engine.requests.count)
+    }
+    #endif
 }

--- a/Tests/ConfigCatTests/CacheTest.swift
+++ b/Tests/ConfigCatTests/CacheTest.swift
@@ -41,8 +41,6 @@ class CacheTests: XCTestCase {
         XCTAssertEqual("local", val)
         XCTAssertEqual(0, engine.requests.count)
         
-        sleep(2)
-        
         let entry2 = try! ConfigEntry.fromConfigJson(json: String(format: testJson, "local2"), eTag: "test-etag2", fetchTime: Date()).get()
         try! cache.write(for: "", value: entry2.serialize())
         


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR fixes a wrong condition (introduced in `11.0.0`) used by the cache validity check. The previous condition did not allow the reloading of the in-memory cache when the external cache data was modified.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
