### PR TITLE
Move the reading of the user object's properties to public scope

### DIFF
--- a/Sources/ConfigCat/ConfigCatUser.swift
+++ b/Sources/ConfigCat/ConfigCatUser.swift
@@ -2,12 +2,14 @@ import Foundation
 
 /// User Object. Contains user attributes which are used for evaluating targeting rules and percentage options.
 public final class ConfigCatUser: NSObject {
-    static let idKey: String = "Identifier"
-    static let emailKey: String = "Email"
-    static let countryKey: String = "Country"
+    @objc public static let idKey: String = "Identifier"
+    @objc public static let emailKey: String = "Email"
+    @objc public static let countryKey: String = "Country"
     
     private var attributes: [String: Any]
-    private(set) var identifier: String
+    
+    /// The user object's identifier.
+    public private(set) var identifier: String
     
     /**
      Initializes a new `ConfigCatUser`.
@@ -76,7 +78,13 @@ public final class ConfigCatUser: NSObject {
         self.identifier = custom[ConfigCatUser.idKey] as? String ?? ""
     }
     
-    func attribute(for key: String) -> Any? {
+    /**
+     Returns the user attribute value identified by the given key.
+     
+     - Parameter key: The key of the user attribute.
+     - Returns: The user attribute value.
+     */
+    @objc public func attribute(for key: String) -> Any? {
         if key.isEmpty {
             assert(false, "key cannot be empty")
         }

--- a/Tests/ConfigCatTests/ConfigCatClientIntegrationTests.swift
+++ b/Tests/ConfigCatTests/ConfigCatClientIntegrationTests.swift
@@ -77,7 +77,7 @@ class ConfigCatClientIntegrationTests: XCTestCase {
             XCTAssertEqual("@configcat.com", details.matchedTargetingRule?.conditions[0].userCondition?.stringArrayValue?.first)
             XCTAssertNil(details.matchedPercentageOption)
             XCTAssertEqual(2, details.matchedTargetingRule?.conditions[0].userCondition?.comparator.rawValue)
-            XCTAssertEqual(user.identifier, details.user?.identifier)
+            XCTAssertEqual(user.attribute(for: ConfigCatUser.idKey) as! String, details.user?.attribute(for: ConfigCatUser.idKey) as! String)
             called = true
         }
         let client = ConfigCatClient.get(sdkKey: "PKDVCLf-Hq-h-kCzMp-L7Q/psuH7BGHoUmdONrzzUOY7A", options: config)


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR allows the reading of the user object's properties from public scope:
```swift
let user = ConfigCatUser("<user-id>")

let id = user.identifier // <user-id>

let attributeValue = user.attribute(for: "<attribute-key>")
```

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
