### PR TITLE
Fix crash in withCheckedContinuation on iOS 18.0

### DIFF
--- a/Sources/ConfigCat/ConfigCatClient.swift
+++ b/Sources/ConfigCat/ConfigCatClient.swift
@@ -351,7 +351,8 @@ public final class ConfigCatClient: NSObject, ConfigCatClientProtocol {
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     @discardableResult
     public func waitForReady() async -> ClientReadyState {
-        await withCheckedContinuation { continuation in
+        // withCheckedContinuation sometimes crashes on iOS 18.0. See https://github.com/RevenueCat/purchases-ios/pull/4286
+        await withUnsafeContinuation { continuation in
             guard let configService = self.configService else {
                 continuation.resume(returning: .hasLocalOverrideFlagDataOnly)
                 return

--- a/Sources/ConfigCat/Extensions.swift
+++ b/Sources/ConfigCat/Extensions.swift
@@ -62,7 +62,7 @@ extension ConfigCatClient {
     #if compiler(>=5.5) && canImport(_Concurrency)
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func getValue<Value>(for key: String, defaultValue: Value, user: ConfigCatUser? = nil) async -> Value {
-        await withCheckedContinuation { continuation in
+        await withUnsafeContinuation { continuation in
             getValue(for: key, defaultValue: defaultValue, user: user) { value in
                 continuation.resume(returning: value)
             }
@@ -71,7 +71,7 @@ extension ConfigCatClient {
     
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func getAnyValue(for key: String, defaultValue: Any?, user: ConfigCatUser? = nil) async -> Any? {
-        await withCheckedContinuation { continuation in
+        await withUnsafeContinuation { continuation in
             getValue(for: key, defaultValue: defaultValue, user: user) { value in
                 continuation.resume(returning: value)
             }
@@ -80,7 +80,7 @@ extension ConfigCatClient {
 
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func getValueDetails<Value>(for key: String, defaultValue: Value, user: ConfigCatUser? = nil) async -> TypedEvaluationDetails<Value> {
-        await withCheckedContinuation { continuation in
+        await withUnsafeContinuation { continuation in
             getValueDetails(for: key, defaultValue: defaultValue, user: user) { details in
                 continuation.resume(returning: details)
             }
@@ -89,7 +89,7 @@ extension ConfigCatClient {
     
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func getAnyValueDetails(for key: String, defaultValue: Any?, user: ConfigCatUser? = nil) async -> TypedEvaluationDetails<Any?> {
-        await withCheckedContinuation { continuation in
+        await withUnsafeContinuation { continuation in
             getValueDetails(for: key, defaultValue: defaultValue, user: user) { details in
                 continuation.resume(returning: details)
             }
@@ -98,7 +98,7 @@ extension ConfigCatClient {
 
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func getAllValueDetails(user: ConfigCatUser? = nil) async -> [EvaluationDetails] {
-        await withCheckedContinuation { continuation in
+        await withUnsafeContinuation { continuation in
             getAllValueDetails(user: user) { details in
                 continuation.resume(returning: details)
             }
@@ -107,7 +107,7 @@ extension ConfigCatClient {
 
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func getAllKeys() async -> [String] {
-        await withCheckedContinuation { continuation in
+        await withUnsafeContinuation { continuation in
             getAllKeys { keys in
                 continuation.resume(returning: keys)
             }
@@ -116,7 +116,7 @@ extension ConfigCatClient {
 
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func getKeyAndValue(for variationId: String) async -> KeyValue? {
-        await withCheckedContinuation { continuation in
+        await withUnsafeContinuation { continuation in
             getKeyAndValue(for: variationId) { value in
                 continuation.resume(returning: value)
             }
@@ -125,7 +125,7 @@ extension ConfigCatClient {
 
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func getAllValues(user: ConfigCatUser? = nil) async -> [String: Any] {
-        await withCheckedContinuation { continuation in
+        await withUnsafeContinuation { continuation in
             getAllValues(user: user) { values in
                 continuation.resume(returning: values)
             }
@@ -135,7 +135,7 @@ extension ConfigCatClient {
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     @discardableResult
     public func forceRefresh() async -> RefreshResult {
-        await withCheckedContinuation { continuation in
+        await withUnsafeContinuation { continuation in
             forceRefresh { result in
                 continuation.resume(returning: result)
             }


### PR DESCRIPTION
### Describe the purpose of your pull request

I've seen crashes on iOS 18.0 in our iOS app in the code of this SDK. The crash seems to be the same as in [other SDKs](https://github.com/RevenueCat/purchases-ios/pull/4286), that use `withCheckedContinuation`, which is actually a bug in iOS 18.0 (apparently fixed on iOS 18.1).

The easy fix for the crash is to use `withUnsafeContinuation` instead, which only has the downside of no longer checking (and logging) if the continuation is not continued/finished. 

This PR applies this fixed everywhere in the SDK to hopefully resolve this issue.

Crash Log:

```

Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
Exception Subtype: KERN_INVALID_ADDRESS at 0x0000000000000004
Exception Codes: 0x0000000000000001, 0x0000000000000004
VM Region Info: 0x4 is not in any region.  Bytes before following region: 4371005436
      REGION TYPE                 START - END      [ VSIZE] PRT/MAX SHRMOD  REGION DETAIL
      UNUSED SPACE AT START
--->  
      __TEXT                   104884000-104b4c000 [ 2848K] r-x/r-x SM=COW  /var/containers/Bundle/Application/19708210-5A4F-4157-9ED0-E2EB9CCCEBB5/Structured.app/Structured
Termination Reason: SIGNAL 11 Segmentation fault: 11
Terminating Process: exc handler [6285]
...
Thread 2:
0   Structured                    	0x00000001050597d0 specialized withCheckedContinuation<A>(isolation:function:_:) + 8 (/<compiler-generated>:0)
1   Structured                    	0x00000001050597d0 ConfigCatClient.waitForReady() + 88
2   Structured                    	0x00000001050597d0 0x104884000 + 8214480 (ConfigCatClient.swift:354)
3   Structured                    	0x0000000104ee21fd closure #1 in TelemetryTracker.launched(properties:) + 1 (Telemetry.swift:117)
4   Structured                    	0x000000010495da09 $sxIeAgHr_xs5Error_pIegHrzo_s8SendableRzlTRyt_Tg5TATQ0_ + 1
5   Structured                    	0x00000001049587d1 thunk for @escaping @callee_guaranteed @async () -> () + 1 (/<compiler-generated>:0)
6   Structured                    	0x0000000104959d71 partial apply for closure #1 in CycleSeasonsManager.observeToggle() + 1 (/<compiler-generated>:0)
7   libswift_Concurrency.dylib    	0x000000018fc5c689 completeTaskWithClosure(swift::AsyncContext*, swift::SwiftError*) + 1 (Task.cpp:471)
```

### Related issues (only if applicable)

Provide links to issues relating to this pull request

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
