### PR TITLE
Config service improvements

### DIFF
--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 0 * * *'
   push:
-    branches: [ '*' ]
+    branches: [ master ]
     paths-ignore:
       - '**.md'
     tags: [ '[0-9]+.[0-9]+.[0-9]+' ]

--- a/ConfigCat.podspec
+++ b/ConfigCat.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name          = "ConfigCat"
-  spec.version       = "11.2.0"
+  spec.version       = "11.3.0"
   spec.summary       = "ConfigCat Swift SDK"
   spec.swift_version = "5.0"
 

--- a/ConfigCat.xcconfig
+++ b/ConfigCat.xcconfig
@@ -38,4 +38,4 @@ SUPPORTED_PLATFORMS = macosx iphoneos iphonesimulator watchos watchsimulator app
 SWIFT_VERSION = 5.0
 
 // ConfigCat SDK version
-MARKETING_VERSION = 11.2.0
+MARKETING_VERSION = 11.3.0

--- a/ConfigCat.xcodeproj/project.pbxproj
+++ b/ConfigCat.xcodeproj/project.pbxproj
@@ -53,8 +53,8 @@
 		F10AC6D02A93B02B006FA496 /* CacheTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10AC6CF2A93B02B006FA496 /* CacheTest.swift */; };
 		F10AC6D22A950197006FA496 /* FlagEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10AC6D12A950197006FA496 /* FlagEvaluator.swift */; };
 		F10AC6D32A9507C4006FA496 /* FlagEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10AC6D12A950197006FA496 /* FlagEvaluator.swift */; };
-		F10AC6D52A9516F5006FA496 /* ConfigCatSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10AC6D42A9516F5006FA496 /* ConfigCatSnapshot.swift */; };
-		F10AC6D62A9516F5006FA496 /* ConfigCatSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10AC6D42A9516F5006FA496 /* ConfigCatSnapshot.swift */; };
+		F10AC6D52A9516F5006FA496 /* ConfigCatClientSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10AC6D42A9516F5006FA496 /* ConfigCatClientSnapshot.swift */; };
+		F10AC6D62A9516F5006FA496 /* ConfigCatClientSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10AC6D42A9516F5006FA496 /* ConfigCatClientSnapshot.swift */; };
 		F11F76BC288AD6CA0097939F /* AsyncAwaitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11F76BB288AD6CA0097939F /* AsyncAwaitTests.swift */; };
 		F11F76BE288AE7540097939F /* SnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11F76BD288AE7540097939F /* SnapshotTests.swift */; };
 		F11F76C0288AE7650097939F /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11F76BF288AE7640097939F /* Extensions.swift */; };
@@ -135,7 +135,7 @@
 		C4FA1B3F278D953300BFA8C3 /* OverrideBehaviour.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OverrideBehaviour.swift; sourceTree = "<group>"; };
 		F10AC6CF2A93B02B006FA496 /* CacheTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheTest.swift; sourceTree = "<group>"; };
 		F10AC6D12A950197006FA496 /* FlagEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagEvaluator.swift; sourceTree = "<group>"; };
-		F10AC6D42A9516F5006FA496 /* ConfigCatSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigCatSnapshot.swift; sourceTree = "<group>"; };
+		F10AC6D42A9516F5006FA496 /* ConfigCatClientSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigCatClientSnapshot.swift; sourceTree = "<group>"; };
 		F10F787D2528950D0021F468 /* DataGovernanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataGovernanceTests.swift; sourceTree = "<group>"; };
 		F11F76BB288AD6CA0097939F /* AsyncAwaitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncAwaitTests.swift; sourceTree = "<group>"; };
 		F11F76BD288AE7540097939F /* SnapshotTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapshotTests.swift; sourceTree = "<group>"; };
@@ -258,7 +258,7 @@
 				F1E1180A257532D700DA245A /* Log.swift */,
 				3F880A41207BE91300087A6B /* Resources */,
 				F10AC6D12A950197006FA496 /* FlagEvaluator.swift */,
-				F10AC6D42A9516F5006FA496 /* ConfigCatSnapshot.swift */,
+				F10AC6D42A9516F5006FA496 /* ConfigCatClientSnapshot.swift */,
 				F1CBE12E2B8CC81700CD2FF9 /* EvaluationLogger.swift */,
 			);
 			name = Sources;
@@ -447,7 +447,7 @@
 				F17DEE28288876F7009C3E48 /* MutableQueue.swift in Sources */,
 				F1BC414728E1D54800F2230A /* EvaluationDetails.swift in Sources */,
 				C4FA1B3D278D919A00BFA8C3 /* OverrideDataSource.swift in Sources */,
-				F10AC6D52A9516F5006FA496 /* ConfigCatSnapshot.swift in Sources */,
+				F10AC6D52A9516F5006FA496 /* ConfigCatClientSnapshot.swift in Sources */,
 				B4BD2AB6258CA6FF007371E2 /* Log.swift in Sources */,
 				B4BD2AB8258CA6FF007371E2 /* KeyValue.swift in Sources */,
 				F10AC6D32A9507C4006FA496 /* FlagEvaluator.swift in Sources */,
@@ -473,7 +473,7 @@
 				F1BC414828E1D54800F2230A /* EvaluationDetails.swift in Sources */,
 				C40CF51527B557EE00D9F88A /* LocalDictionaryDataSource.swift in Sources */,
 				F1B1D8B628FF2C830034165E /* ConfigCatOptions.swift in Sources */,
-				F10AC6D62A9516F5006FA496 /* ConfigCatSnapshot.swift in Sources */,
+				F10AC6D62A9516F5006FA496 /* ConfigCatClientSnapshot.swift in Sources */,
 				F10AC6D22A950197006FA496 /* FlagEvaluator.swift in Sources */,
 				B4BD2AE6258CA7DF007371E2 /* ConfigFetcher.swift in Sources */,
 				B4BD2AE7258CA7DF007371E2 /* RolloutIntegrationV1Tests.swift in Sources */,

--- a/ConfigCat.xcodeproj/project.pbxproj
+++ b/ConfigCat.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 		F10AC6D32A9507C4006FA496 /* FlagEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10AC6D12A950197006FA496 /* FlagEvaluator.swift */; };
 		F10AC6D52A9516F5006FA496 /* ConfigCatClientSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10AC6D42A9516F5006FA496 /* ConfigCatClientSnapshot.swift */; };
 		F10AC6D62A9516F5006FA496 /* ConfigCatClientSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10AC6D42A9516F5006FA496 /* ConfigCatClientSnapshot.swift */; };
+		F1109D0C2DF99347000EF1AA /* SnapshotBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1109D0B2DF9933F000EF1AA /* SnapshotBuilder.swift */; };
+		F1109D0D2DF99347000EF1AA /* SnapshotBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1109D0B2DF9933F000EF1AA /* SnapshotBuilder.swift */; };
 		F11F76BC288AD6CA0097939F /* AsyncAwaitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11F76BB288AD6CA0097939F /* AsyncAwaitTests.swift */; };
 		F11F76BE288AE7540097939F /* SnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11F76BD288AE7540097939F /* SnapshotTests.swift */; };
 		F11F76C0288AE7650097939F /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11F76BF288AE7640097939F /* Extensions.swift */; };
@@ -137,6 +139,7 @@
 		F10AC6D12A950197006FA496 /* FlagEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlagEvaluator.swift; sourceTree = "<group>"; };
 		F10AC6D42A9516F5006FA496 /* ConfigCatClientSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigCatClientSnapshot.swift; sourceTree = "<group>"; };
 		F10F787D2528950D0021F468 /* DataGovernanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataGovernanceTests.swift; sourceTree = "<group>"; };
+		F1109D0B2DF9933F000EF1AA /* SnapshotBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotBuilder.swift; sourceTree = "<group>"; };
 		F11F76BB288AD6CA0097939F /* AsyncAwaitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncAwaitTests.swift; sourceTree = "<group>"; };
 		F11F76BD288AE7540097939F /* SnapshotTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapshotTests.swift; sourceTree = "<group>"; };
 		F11F76BF288AE7640097939F /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
@@ -234,6 +237,7 @@
 		3F880A42207BE91900087A6B /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				F1109D0B2DF9933F000EF1AA /* SnapshotBuilder.swift */,
 				F1B1D8B428FF2C830034165E /* ConfigCatOptions.swift */,
 				F1BC414428E1D54800F2230A /* EvaluationDetails.swift */,
 				F11F76BF288AE7640097939F /* Extensions.swift */,
@@ -451,6 +455,7 @@
 				B4BD2AB6258CA6FF007371E2 /* Log.swift in Sources */,
 				B4BD2AB8258CA6FF007371E2 /* KeyValue.swift in Sources */,
 				F10AC6D32A9507C4006FA496 /* FlagEvaluator.swift in Sources */,
+				F1109D0D2DF99347000EF1AA /* SnapshotBuilder.swift in Sources */,
 				B4BD2AB9258CA6FF007371E2 /* Config.swift in Sources */,
 				B4BD2ABA258CA6FF007371E2 /* RolloutEvaluator.swift in Sources */,
 				B4BD2ABE258CA6FF007371E2 /* Synced.swift in Sources */,
@@ -509,6 +514,7 @@
 				F183A2082B9096A30015967E /* EvaluationLogTests.swift in Sources */,
 				B4BD2B00258CA7DF007371E2 /* Mock.swift in Sources */,
 				F11F76BE288AE7540097939F /* SnapshotTests.swift in Sources */,
+				F1109D0C2DF99347000EF1AA /* SnapshotBuilder.swift in Sources */,
 				C40CF51227B5533800D9F88A /* LocalTests.swift in Sources */,
 				B4BD2B02258CA7DF007371E2 /* ManualPollingTests.swift in Sources */,
 				F17DEE29288876F7009C3E48 /* MutableQueue.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The following device platform versions are supported:
 
   ``` swift
   dependencies: [
-    .package(url: "https://github.com/configcat/swift-sdk", from: "11.2.0")
+    .package(url: "https://github.com/configcat/swift-sdk", from: "11.3.0")
   ]
   ```
 

--- a/Sources/ConfigCat/ConfigCatClient.swift
+++ b/Sources/ConfigCat/ConfigCatClient.swift
@@ -69,7 +69,7 @@ public final class ConfigCatClient: NSObject, ConfigCatClientProtocol {
     }
 
     /**
-     Creates a new or gets an already existing `ConfigCatClient` for the given sdkKey.
+     Creates a new or gets an already existing `ConfigCatClient` for the given `sdkKey`.
 
      - Parameters:
        - sdkKey: The SDK Key for to communicate with the ConfigCat services.
@@ -112,7 +112,7 @@ public final class ConfigCatClient: NSObject, ConfigCatClientProtocol {
     }
 
     /**
-     Creates a new or gets an already existing ConfigCatClient for the given sdkKey.
+     Creates a new or gets an already existing ConfigCatClient for the given `sdkKey`.
 
      - Parameters:
        - sdkKey: The SDK Key for to communicate with the ConfigCat services.
@@ -345,10 +345,11 @@ public final class ConfigCatClient: NSObject, ConfigCatClientProtocol {
     }
     
     /**
-     Captures the SDK's internally cached config data.
+     Captures the current state of the client.
+     The resulting snapshot can be used to synchronously evaluate feature flags and settings based on the captured state.
      
-     It does not attempt to update it by synchronizing with the external cache or by fetching
-     the latest version from the ConfigCat CDN.
+     The operation captures the internally cached config data.
+     It does not attempt to update it by synchronizing with the external cache or by fetching the latest version from the ConfigCat CDN.
      
      Therefore, it is recommended to use snapshots in conjunction with the Auto Polling mode,
      where the SDK automatically updates the internal cache in the background.
@@ -459,17 +460,17 @@ public final class ConfigCatClient: NSObject, ConfigCatClientProtocol {
         defaultUser = nil
     }
 
-    /// Configures the SDK to allow HTTP requests.
+    /// Configures the client to allow HTTP requests.
     @objc public func setOnline() {
         configService?.setOnline()
     }
 
-    /// Configures the SDK to not initiate HTTP requests.
+    /// Configures the client to not initiate HTTP requests but work using the cache only.
     @objc public func setOffline() {
         configService?.setOffline()
     }
 
-    /// True when the SDK is configured not to initiate HTTP requests, otherwise false.
+    /// Returns `true` when the client is configured not to initiate HTTP requests, otherwise `false`.
     @objc public var isOffline: Bool {
         get {
             configService?.isOffline ?? true

--- a/Sources/ConfigCat/ConfigCatClient.swift
+++ b/Sources/ConfigCat/ConfigCatClient.swift
@@ -200,7 +200,7 @@ public final class ConfigCatClient: NSObject, ConfigCatClientProtocol {
         let evalUser = user ?? defaultUser
         
         if let error = flagEvaluator.validateFlagType(of: Value.self, key: key, defaultValue: defaultValue, user: evalUser) {
-            completion(TypedEvaluationDetails<Value>.fromError(key: key, value: defaultValue, error: error, errorCode: .invalidUserInput, user: evalUser))
+            completion(TypedEvaluationDetails<Value>.fromError(value: defaultValue, details: error))
             return
         }
         

--- a/Sources/ConfigCat/ConfigCatClient.swift
+++ b/Sources/ConfigCat/ConfigCatClient.swift
@@ -200,7 +200,7 @@ public final class ConfigCatClient: NSObject, ConfigCatClientProtocol {
         let evalUser = user ?? defaultUser
         
         if let error = flagEvaluator.validateFlagType(of: Value.self, key: key, defaultValue: defaultValue, user: evalUser) {
-            completion(TypedEvaluationDetails<Value>.fromError(key: key, value: defaultValue, error: error, errorCode: .settingValueTypeMismatch, user: evalUser))
+            completion(TypedEvaluationDetails<Value>.fromError(key: key, value: defaultValue, error: error, errorCode: .invalidUserInput, user: evalUser))
             return
         }
         
@@ -329,7 +329,8 @@ public final class ConfigCatClient: NSObject, ConfigCatClientProtocol {
     }
 
     /**
-     Initiates a force refresh asynchronously on the cached configuration.
+     Updates the internally cached config by synchronizing with the external cache (if any),
+     then by fetching the latest version from the ConfigCat CDN (provided that the client is online).
 
      - Parameter completion: The function which will be called when refresh completed successfully.
      */
@@ -343,12 +344,36 @@ public final class ConfigCatClient: NSObject, ConfigCatClientProtocol {
         }
     }
     
+    /**
+     Captures the SDK's internally cached config data.
+     
+     It does not attempt to update it by synchronizing with the external cache or by fetching
+     the latest version from the ConfigCat CDN.
+     
+     Therefore, it is recommended to use snapshots in conjunction with the Auto Polling mode,
+     where the SDK automatically updates the internal cache in the background.
+     
+     For other polling modes, you will need to manually initiate a cache
+     update by invoking `.forceRefresh()`.
+     */
     @objc public func snapshot() -> ConfigCatClientSnapshot {
         let inMemorySettings = getInMemorySettings()
         return ConfigCatClientSnapshot(flagEvaluator: flagEvaluator, settingsSnapshot: inMemorySettings.0, cacheState: inMemorySettings.1, defaultUser: defaultUser, log: log)
     }
     
     #if compiler(>=5.5) && canImport(_Concurrency)
+    /**
+     Waits for the client to reach the ready state, i.e. to complete initialization.
+     
+     Ready state is reached as soon as the initial sync with the external cache (if any) completes.
+     If this does not produce up-to-date config data, and the client is online (i.e. HTTP requests are allowed),
+     the first config fetch operation is also awaited in Auto Polling mode before ready state is reported.
+     
+     That is, reaching the ready state usually means the client is ready to evaluate feature flags and settings.
+     However, please note that this is not guaranteed. In case of initialization failure or timeout,
+     the internal cache may be empty or expired even after the ready state is reported. You can verify this by
+     checking the return value.
+     */
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     @discardableResult
     public func waitForReady() async -> ClientCacheState {

--- a/Sources/ConfigCat/ConfigCatClientProtocol.swift
+++ b/Sources/ConfigCat/ConfigCatClientProtocol.swift
@@ -119,7 +119,10 @@ public protocol ConfigCatClientProtocol {
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func getAllValues(user: ConfigCatUser?) async -> [String: Any]
 
-    /// Initiates a force refresh asynchronously on the cached configuration.
+    /**
+     Updates the internally cached config by synchronizing with the external cache (if any),
+     then by fetching the latest version from the ConfigCat CDN (provided that the client is online).
+     */
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func forceRefresh() async -> RefreshResult
     

--- a/Sources/ConfigCat/ConfigCatClientProtocol.swift
+++ b/Sources/ConfigCat/ConfigCatClientProtocol.swift
@@ -55,14 +55,25 @@ public protocol ConfigCatClientProtocol {
     var isOffline: Bool { get }
 
     /**
-     Initiates a force refresh asynchronously on the cached configuration.
+     Updates the internally cached config by synchronizing with the external cache (if any),
+     then by fetching the latest version from the ConfigCat CDN (provided that the client is online).
 
-     - Parameter completion: The function which will be called when refresh completed.
+     - Parameter completion: The function which will be called when refresh completed successfully.
      */
     func forceRefresh(completion: @escaping (RefreshResult) -> ())
     
-    /// Returns a snapshot of the current state of the feature flag data within the SDK.
-    /// The snapshot allows synchronous feature flag evaluation on the captured feature flag data.
+    /**
+     Captures the SDK's internally cached config data.
+     
+     It does not attempt to update it by synchronizing with the external cache or by fetching
+     the latest version from the ConfigCat CDN.
+     
+     Therefore, it is recommended to use snapshots in conjunction with the Auto Polling mode,
+     where the SDK automatically updates the internal cache in the background.
+     
+     For other polling modes, you will need to manually initiate a cache
+     update by invoking `.forceRefresh()`.
+     */
     func snapshot() -> ConfigCatClientSnapshot
 
     /// Async/await interface
@@ -111,7 +122,18 @@ public protocol ConfigCatClientProtocol {
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func forceRefresh() async -> RefreshResult
     
-    /// Awaits for SDK initialization.
+    /**
+     Waits for the client to reach the ready state, i.e. to complete initialization.
+     
+     Ready state is reached as soon as the initial sync with the external cache (if any) completes.
+     If this does not produce up-to-date config data, and the client is online (i.e. HTTP requests are allowed),
+     the first config fetch operation is also awaited in Auto Polling mode before ready state is reported.
+     
+     That is, reaching the ready state usually means the client is ready to evaluate feature flags and settings.
+     However, please note that this is not guaranteed. In case of initialization failure or timeout,
+     the internal cache may be empty or expired even after the ready state is reported. You can verify this by
+     checking the return value.
+     */
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func waitForReady() async -> ClientCacheState
     #endif

--- a/Sources/ConfigCat/ConfigCatClientProtocol.swift
+++ b/Sources/ConfigCat/ConfigCatClientProtocol.swift
@@ -45,13 +45,13 @@ public protocol ConfigCatClientProtocol {
     /// Sets the default user to null.
     func clearDefaultUser()
 
-    /// Configures the SDK to allow HTTP requests.
+    /// Configures the client to allow HTTP requests.
     func setOnline()
 
-    /// Configures the SDK to not initiate HTTP requests and work only from its cache.
+    /// Configures the client to not initiate HTTP requests but work using the cache only.
     func setOffline()
 
-    /// True when the SDK is configured not to initiate HTTP requests, otherwise false.
+    /// Returns `true` when the client is configured not to initiate HTTP requests, otherwise `false`.
     var isOffline: Bool { get }
 
     /**
@@ -63,10 +63,11 @@ public protocol ConfigCatClientProtocol {
     func forceRefresh(completion: @escaping (RefreshResult) -> ())
     
     /**
-     Captures the SDK's internally cached config data.
+     Captures the current state of the client.
+     The resulting snapshot can be used to synchronously evaluate feature flags and settings based on the captured state.
      
-     It does not attempt to update it by synchronizing with the external cache or by fetching
-     the latest version from the ConfigCat CDN.
+     The operation captures the internally cached config data.
+     It does not attempt to update it by synchronizing with the external cache or by fetching the latest version from the ConfigCat CDN.
      
      Therefore, it is recommended to use snapshots in conjunction with the Auto Polling mode,
      where the SDK automatically updates the internal cache in the background.

--- a/Sources/ConfigCat/ConfigCatClientProtocol.swift
+++ b/Sources/ConfigCat/ConfigCatClientProtocol.swift
@@ -63,7 +63,7 @@ public protocol ConfigCatClientProtocol {
     
     /// Returns a snapshot of the current state of the feature flag data within the SDK.
     /// The snapshot allows synchronous feature flag evaluation on the captured feature flag data.
-    func snapshot() -> ConfigCatSnapshot
+    func snapshot() -> ConfigCatClientSnapshot
 
     /// Async/await interface
     #if compiler(>=5.5) && canImport(_Concurrency)
@@ -113,7 +113,7 @@ public protocol ConfigCatClientProtocol {
     
     /// Awaits for SDK initialization.
     @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    func waitForReady() async -> ClientReadyState
+    func waitForReady() async -> ClientCacheState
     #endif
 
     /// Objective-C interface

--- a/Sources/ConfigCat/ConfigCatClientSnapshot.swift
+++ b/Sources/ConfigCat/ConfigCatClientSnapshot.swift
@@ -108,32 +108,4 @@ public final class ConfigCatClientSnapshot: NSObject {
         }
         return [String](settingsSnapshot.settings.keys)
     }
-
-    /// Gets the values of all feature flags or settings.
-    @objc public func getAllValues(user: ConfigCatUser? = nil) -> [String: Any]
-    {
-        if settingsSnapshot.isEmpty {
-            self.log.error(
-                eventId: 1000,
-                message: "Config JSON is not present. Returning empty array."
-            )
-            return [:]
-        }
-        var allValues = [String: Any]()
-        for key in settingsSnapshot.settings.keys {
-            guard let setting = settingsSnapshot.settings[key] else {
-                continue
-            }
-            if let details = self.flagEvaluator.evaluateFlag(
-                for: setting,
-                key: key,
-                user: user ?? self.defaultUser,
-                fetchTime: settingsSnapshot.fetchTime,
-                settings: settingsSnapshot.settings
-            ) {
-                allValues[key] = details.value
-            }
-        }
-        return allValues
-    }
 }

--- a/Sources/ConfigCat/ConfigCatClientSnapshot.swift
+++ b/Sources/ConfigCat/ConfigCatClientSnapshot.swift
@@ -1,62 +1,111 @@
 import Foundation
 
-public final class ConfigCatSnapshot: NSObject {
+public final class ConfigCatClientSnapshot: NSObject {
     private let flagEvaluator: FlagEvaluator
     private let settingsSnapshot: SettingsResult
     private let defaultUser: ConfigCatUser?
     private let log: InternalLogger
-    
-    init(flagEvaluator: FlagEvaluator, settingsSnapshot: SettingsResult, defaultUser: ConfigCatUser?, log: InternalLogger) {
+
+    /**
+     The state of the internal cache at the time the snapshot was created.
+     */
+    @objc public let cacheState: ClientCacheState
+
+    init(
+        flagEvaluator: FlagEvaluator,
+        settingsSnapshot: SettingsResult,
+        cacheState: ClientCacheState,
+        defaultUser: ConfigCatUser?,
+        log: InternalLogger
+    ) {
         self.flagEvaluator = flagEvaluator
         self.settingsSnapshot = settingsSnapshot
         self.defaultUser = defaultUser
         self.log = log
+        self.cacheState = cacheState
     }
-    
+
     /**
      Gets the value of a feature flag or setting identified by the given `key`. The generic parameter `Value` represents the type of the desired feature flag or setting. Only the following types are allowed: `String`, `Bool`, `Int`, `Double`, `Any` (both nullable and non-nullable).
-     
+    
      - Parameter key: the identifier of the feature flag or setting.
      - Parameter defaultValue: in case of any failure, this value will be returned.
      - Parameter user: the user object to identify the caller.
      - Returns: The evaluated feature flag value.
      */
-    public func getValue<Value>(for key: String, defaultValue: Value, user: ConfigCatUser? = nil) -> Value {
+    public func getValue<Value>(
+        for key: String,
+        defaultValue: Value,
+        user: ConfigCatUser? = nil
+    ) -> Value {
         assert(!key.isEmpty, "key cannot be empty")
         let evalUser = user ?? defaultUser
-        
-        if let _ = flagEvaluator.validateFlagType(of: Value.self, key: key, defaultValue: defaultValue, user: evalUser) {
+
+        if flagEvaluator.validateFlagType(
+            of: Value.self,
+            key: key,
+            defaultValue: defaultValue,
+            user: evalUser
+        ) != nil {
             return defaultValue
         }
-        
-        let evalDetails = self.flagEvaluator.evaluateFlag(result: settingsSnapshot, key: key, defaultValue: defaultValue, user: evalUser)
+
+        let evalDetails = self.flagEvaluator.evaluateFlag(
+            result: settingsSnapshot,
+            key: key,
+            defaultValue: defaultValue,
+            user: evalUser
+        )
         return evalDetails.value
     }
 
     /**
      Gets the value and evaluation details of a feature flag or setting identified by the given `key`. The generic parameter `Value` represents the type of the desired feature flag or setting. Only the following types are allowed: `String`, `Bool`, `Int`, `Double`, `Any` (both nullable and non-nullable).
-
+    
      - Parameter key: the identifier of the feature flag or setting.
      - Parameter defaultValue: in case of any failure, this value will be returned.
      - Parameter user: the user object to identify the caller.
      - Returns: The evaluation details.
      */
-    public func getValueDetails<Value>(for key: String, defaultValue: Value, user: ConfigCatUser? = nil) -> TypedEvaluationDetails<Value> {
+    public func getValueDetails<Value>(
+        for key: String,
+        defaultValue: Value,
+        user: ConfigCatUser? = nil
+    ) -> TypedEvaluationDetails<Value> {
         assert(!key.isEmpty, "key cannot be empty")
         let evalUser = user ?? defaultUser
-        
-        if let error = flagEvaluator.validateFlagType(of: Value.self, key: key, defaultValue: defaultValue, user: evalUser) {
-            return TypedEvaluationDetails<Value>.fromError(key: key, value: defaultValue, error: error, user: evalUser)
+
+        if let error = flagEvaluator.validateFlagType(
+            of: Value.self,
+            key: key,
+            defaultValue: defaultValue,
+            user: evalUser
+        ) {
+            return TypedEvaluationDetails<Value>.fromError(
+                key: key,
+                value: defaultValue,
+                error: error,
+                errorCode: .settingValueTypeMismatch,
+                user: evalUser
+            )
         }
-        
-        let evalDetails = self.flagEvaluator.evaluateFlag(result: settingsSnapshot, key: key, defaultValue: defaultValue, user: evalUser)
+
+        let evalDetails = self.flagEvaluator.evaluateFlag(
+            result: settingsSnapshot,
+            key: key,
+            defaultValue: defaultValue,
+            user: evalUser
+        )
         return evalDetails
     }
-    
+
     /// Gets all the setting keys within the snapshot.
     @objc public func getAllKeys() -> [String] {
         if settingsSnapshot.isEmpty {
-            log.error(eventId: 1000, message: "Config JSON is not present. Returning empty array.")
+            log.error(
+                eventId: 1000,
+                message: "Config JSON is not present. Returning empty array."
+            )
             return []
         }
         return [String](settingsSnapshot.settings.keys)

--- a/Sources/ConfigCat/ConfigCatClientSnapshot.swift
+++ b/Sources/ConfigCat/ConfigCatClientSnapshot.swift
@@ -83,11 +83,8 @@ public final class ConfigCatClientSnapshot: NSObject {
             user: evalUser
         ) {
             return TypedEvaluationDetails<Value>.fromError(
-                key: key,
                 value: defaultValue,
-                error: error,
-                errorCode: .invalidUserInput,
-                user: evalUser
+                details: error
             )
         }
 

--- a/Sources/ConfigCat/ConfigCatClientSnapshot.swift
+++ b/Sources/ConfigCat/ConfigCatClientSnapshot.swift
@@ -111,4 +111,32 @@ public final class ConfigCatClientSnapshot: NSObject {
         }
         return [String](settingsSnapshot.settings.keys)
     }
+
+    /// Gets the values of all feature flags or settings.
+    @objc public func getAllValues(user: ConfigCatUser? = nil) -> [String: Any]
+    {
+        if settingsSnapshot.isEmpty {
+            self.log.error(
+                eventId: 1000,
+                message: "Config JSON is not present. Returning empty array."
+            )
+            return [:]
+        }
+        var allValues = [String: Any]()
+        for key in settingsSnapshot.settings.keys {
+            guard let setting = settingsSnapshot.settings[key] else {
+                continue
+            }
+            if let details = self.flagEvaluator.evaluateFlag(
+                for: setting,
+                key: key,
+                user: user ?? self.defaultUser,
+                fetchTime: settingsSnapshot.fetchTime,
+                settings: settingsSnapshot.settings
+            ) {
+                allValues[key] = details.value
+            }
+        }
+        return allValues
+    }
 }

--- a/Sources/ConfigCat/ConfigCatClientSnapshot.swift
+++ b/Sources/ConfigCat/ConfigCatClientSnapshot.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Represents the state of `ConfigCatClient` captured at a specific point in time.
 public final class ConfigCatClientSnapshot: NSObject {
     private let flagEvaluator: FlagEvaluator
     private let settingsSnapshot: SettingsResult
@@ -85,7 +86,7 @@ public final class ConfigCatClientSnapshot: NSObject {
                 key: key,
                 value: defaultValue,
                 error: error,
-                errorCode: .settingValueTypeMismatch,
+                errorCode: .invalidUserInput,
                 user: evalUser
             )
         }

--- a/Sources/ConfigCat/ConfigCatOptions.swift
+++ b/Sources/ConfigCat/ConfigCatOptions.swift
@@ -47,15 +47,15 @@ public final class ConfigCatOptions: NSObject {
     }
 }
 
-/// Describes the initialization state of the `ConfigCatClient`.
+/// Defines the possible states of the internal cache.
 @objc public enum ClientCacheState: Int {
-    /// The SDK has no feature flag data neither from the cache nor from the ConfigCat CDN.
+    /// No config data is available in the internal cache.
     case noFlagData
-    /// The SDK runs with local only feature flag data.
+    /// Only config data provided by local flag override is available in the internal cache.
     case hasLocalOverrideFlagDataOnly
-    /// The SDK has feature flag data to work with only from the cache.
+    /// Only expired config data obtained from the external cache or the ConfigCat CDN is available in the internal cache.
     case hasCachedFlagDataOnly
-    /// The SDK works with the latest feature flag data received from the ConfigCat CDN.
+    /// Up-to-date config data obtained from the external cache or the ConfigCat CDN is available in the internal cache.
     case hasUpToDateFlagData
 }
 

--- a/Sources/ConfigCat/ConfigCatOptions.swift
+++ b/Sources/ConfigCat/ConfigCatOptions.swift
@@ -67,7 +67,7 @@ public final class Hooks: NSObject {
     private var onReadyWithSnapshot: [(ConfigCatClientSnapshot) -> ()] = []
     private var onFlagEvaluated: [(EvaluationDetails) -> ()] = []
     private var onConfigChanged: [(Config) -> ()] = []
-    private var onConfigChangedWithSnapshot: [(ConfigCatClientSnapshot) -> ()] = []
+    private var onConfigChangedWithSnapshot: [(Config, ConfigCatClientSnapshot) -> ()] = []
     private var onError: [(String) -> ()] = []
 
     /**
@@ -88,10 +88,10 @@ public final class Hooks: NSObject {
      Subscribes a handler to the `onReadyWithSnapshot` hook.
      - Parameter handler: The handler to subscribe.
      */
-    @objc public func addOnReadyWithSnapshot(handler: @escaping (ConfigCatClientSnapshot) -> ()) {
+    @objc public func addOnReady(snapshotHandler: @escaping (ConfigCatClientSnapshot) -> ()) {
         mutex.lock()
         defer { mutex.unlock() }
-        onReadyWithSnapshot.append(handler)
+        onReadyWithSnapshot.append(snapshotHandler)
     }
 
     /**
@@ -118,10 +118,10 @@ public final class Hooks: NSObject {
      Subscribes a handler to the `onConfigChangedWithSnapshot` hook.
      - Parameter handler: The handler to subscribe.
      */
-    @objc public func addOnConfigChangedWithSnapshot(handler: @escaping (ConfigCatClientSnapshot) -> ()) {
+    @objc public func addOnConfigChanged(snapshotHandler: @escaping (Config, ConfigCatClientSnapshot) -> ()) {
         mutex.lock()
         defer { mutex.unlock() }
-        onConfigChangedWithSnapshot.append(handler)
+        onConfigChangedWithSnapshot.append(snapshotHandler)
     }
 
     /**
@@ -158,7 +158,7 @@ public final class Hooks: NSObject {
         if !onConfigChangedWithSnapshot.isEmpty {
             let snapshot = snapshotBuilder.buildSnapshot(inMemoryResult: inMemoryResult)
             for item in onConfigChangedWithSnapshot {
-                item(snapshot);
+                item(inMemoryResult.entry.config, snapshot);
             }
         }
     }

--- a/Sources/ConfigCat/ConfigCatOptions.swift
+++ b/Sources/ConfigCat/ConfigCatOptions.swift
@@ -48,7 +48,7 @@ public final class ConfigCatOptions: NSObject {
 }
 
 /// Describes the initialization state of the `ConfigCatClient`.
-@objc public enum ClientReadyState: Int {
+@objc public enum ClientCacheState: Int {
     /// The SDK has no feature flag data neither from the cache nor from the ConfigCat CDN.
     case noFlagData
     /// The SDK runs with local only feature flag data.
@@ -62,8 +62,8 @@ public final class ConfigCatOptions: NSObject {
 /// Hooks for events sent by `ConfigCatClient`.
 public final class Hooks: NSObject {
     private let mutex: Mutex = Mutex(recursive: true);
-    private var readyState: ClientReadyState?
-    private var onReady: [(ClientReadyState) -> ()] = []
+    private var readyState: ClientCacheState?
+    private var onReady: [(ClientCacheState) -> ()] = []
     private var onFlagEvaluated: [(EvaluationDetails) -> ()] = []
     private var onConfigChanged: [(Config) -> ()] = []
     private var onError: [(String) -> ()] = []
@@ -72,7 +72,7 @@ public final class Hooks: NSObject {
      Subscribes a handler to the `onReady` hook.
      - Parameter handler: The handler to subscribe.
      */
-    @objc public func addOnReady(handler: @escaping (ClientReadyState) -> ()) {
+    @objc public func addOnReady(handler: @escaping (ClientCacheState) -> ()) {
         mutex.lock()
         defer { mutex.unlock() }
         if let readyState = self.readyState {
@@ -112,7 +112,7 @@ public final class Hooks: NSObject {
         onError.append(handler)
     }
 
-    func invokeOnReady(state: ClientReadyState) {
+    func invokeOnReady(state: ClientCacheState) {
         mutex.lock()
         defer { mutex.unlock() }
         readyState = state

--- a/Sources/ConfigCat/ConfigCatOptions.swift
+++ b/Sources/ConfigCat/ConfigCatOptions.swift
@@ -71,7 +71,7 @@ public final class Hooks: NSObject {
     private var onError: [(String) -> ()] = []
 
     /**
-     Subscribes a handler to the `onReady` hook.
+     Subscribes a handler to the `onReady` hook with a `ClientCacheState` parameter.
      - Parameter handler: The handler to subscribe.
      */
     @objc public func addOnReady(handler: @escaping (ClientCacheState) -> ()) {
@@ -85,7 +85,10 @@ public final class Hooks: NSObject {
     }
     
     /**
-     Subscribes a handler to the `onReadyWithSnapshot` hook.
+     Subscribes a handler to the `onReady` hook with a `ConfigCatClientSnapshot` parameter.
+     
+     Late subscriptions (through the `client.hooks` property) might not get notified if the client reached the ready state before the subscription.
+     
      - Parameter handler: The handler to subscribe.
      */
     @objc public func addOnReady(snapshotHandler: @escaping (ConfigCatClientSnapshot) -> ()) {
@@ -108,6 +111,7 @@ public final class Hooks: NSObject {
      Subscribes a handler to the `onConfigChanged` hook.
      - Parameter handler: The handler to subscribe.
      */
+    @available(*, deprecated, message: "Use addOnConfigChanged(snapshotHandler:) instead.")
     @objc public func addOnConfigChanged(handler: @escaping (Config) -> ()) {
         mutex.lock()
         defer { mutex.unlock() }

--- a/Sources/ConfigCat/ConfigService.swift
+++ b/Sources/ConfigCat/ConfigService.swift
@@ -18,19 +18,58 @@ class SettingsResult {
     static let empty = SettingsResult(settings: [:], fetchTime: .distantPast)
 }
 
+class InMemoryResult {
+    let entry: ConfigEntry
+    let cacheState: ClientCacheState
+    
+    init(entry: ConfigEntry, cacheState: ClientCacheState) {
+        self.entry = entry
+        self.cacheState = cacheState
+    }
+}
+
+/**
+ Specifies the possible evaluation error codes.
+ */
+@objc public enum RefreshErrorCode: Int {
+    /** An unexpected error occurred during the refresh operation. */
+    case unexpectedError = -1
+    /** No error occurred (the refresh operation was successful). */
+    case none = 0
+    /**
+     The refresh operation failed because the client is configured to use the `OverrideBehaviour.LocalOnly` override behavior,
+     which prevents synchronization with the external cache and making HTTP requests.
+     */
+    case localOnlyClient = 1
+    /** The refresh operation failed because the client is in offline mode, it cannot initiate HTTP requests. */
+    case offlineClient = 3200
+    /** The refresh operation failed because a HTTP response indicating an invalid SDK Key was received (403 Forbidden or 404 Not Found). */
+    case invalidSdkKey = 1100
+    /** The refresh operation failed because an invalid HTTP response was received (unexpected HTTP status code). */
+    case unexpectedHttpResponse = 1101
+    /** The refresh operation failed because the HTTP request timed out. */
+    case httpRequestTimeout = 1102
+    /** The refresh operation failed because the HTTP request failed (most likely, due to a local network issue). */
+    case httpRequestFailure = 1103
+    /** The refresh operation failed because an invalid HTTP response was received (200 OK with an invalid content). */
+    case invalidHttpResponseContent = 1105
+}
+
 public final class RefreshResult: NSObject {
     @objc public let success: Bool
     @objc public let error: String?
+    @objc public let errorCode: RefreshErrorCode
 
-    init(success: Bool, error: String? = nil) {
+    init(success: Bool, errorCode: RefreshErrorCode, error: String? = nil) {
         self.success = success
         self.error = error
+        self.errorCode = errorCode
     }
 }
 
 enum FetchResult {
     case success(ConfigEntry)
-    case failure(String, ConfigEntry)
+    case failure(String, RefreshErrorCode, ConfigEntry)
 }
 
 class ConfigService {
@@ -58,7 +97,7 @@ class ConfigService {
         self.offline = offline
         cacheKey = Utils.generateCacheKey(sdkKey: sdkKey)
 
-        if let autoPoll = pollingMode as? AutoPollingMode, !offline {
+        if let autoPoll = pollingMode as? AutoPollingMode {
 
             startPoll(mode: autoPoll)
 
@@ -84,7 +123,11 @@ class ConfigService {
             initTimer?.resume()
         } else {
             // Sync up with cache before reporting ready state
-            cachedEntry = readCache()
+            let entry = readCache()
+            if !entry.isEmpty && entry != cachedEntry {
+                cachedEntry = entry
+                hooks.invokeOnConfigChanged(config: entry.config)
+            }
             setInitialized()
         }
     }
@@ -114,7 +157,7 @@ class ConfigService {
             case .success(let entry): completion(!entry.isEmpty
                                                  ? SettingsResult(settings: entry.config.settings, fetchTime: entry.fetchTime)
                                                  : .empty)
-            case .failure(_, let entry): completion(!entry.isEmpty
+            case .failure(_, _, let entry): completion(!entry.isEmpty
                                                     ? SettingsResult(settings: entry.config.settings, fetchTime: entry.fetchTime)
                                                     : .empty)
             }
@@ -122,17 +165,17 @@ class ConfigService {
     }
 
     func refresh(completion: @escaping (RefreshResult) -> Void) {
-        if isOffline {
+        if isOffline && cache == nil {
             let offlineWarning = "Client is in offline mode, it cannot initiate HTTP calls."
             log.warning(eventId: 3200, message: offlineWarning)
-            completion(RefreshResult(success: false, error: offlineWarning))
+            completion(RefreshResult(success: false, errorCode: .offlineClient, error: offlineWarning))
             return
         }
 
         fetchIfOlder(threshold: .distantFuture) { result in
             switch result {
-            case .success: completion(RefreshResult(success: true))
-            case .failure(let error, _): completion(RefreshResult(success: false, error: error))
+            case .success: completion(RefreshResult(success: true, errorCode: .none))
+            case .failure(let error, let errorCode, _): completion(RefreshResult(success: false, errorCode: errorCode, error: error))
             }
         }
     }
@@ -142,6 +185,8 @@ class ConfigService {
         defer { mutex.unlock() }
         if !offline { return }
         offline = false
+        pollTimer?.cancel()
+        pollTimer = nil
         if let autoPoll = pollingMode as? AutoPollingMode {
             startPoll(mode: autoPoll)
         }
@@ -153,8 +198,6 @@ class ConfigService {
         defer { mutex.unlock() }
         if offline { return }
         offline = true
-        pollTimer?.cancel()
-        pollTimer = nil
         log.info(eventId: 5200, message: "Switched to OFFLINE mode.")
     }
 
@@ -166,7 +209,7 @@ class ConfigService {
         }
     }
     
-    func onReady(completion: @escaping (ClientReadyState) -> Void) {
+    func onReady(completion: @escaping (ClientCacheState) -> Void) {
         mutex.lock()
         defer { mutex.unlock() }
         if initialized {
@@ -176,11 +219,11 @@ class ConfigService {
         }
     }
     
-    var inMemory: ConfigEntry {
+    var inMemory: InMemoryResult {
         get {
             mutex.lock()
             defer { mutex.unlock() }
-            return cachedEntry
+            return InMemoryResult(entry: cachedEntry, cacheState: determineReadyState())
         }
     }
 
@@ -201,6 +244,7 @@ class ConfigService {
         }
         // If we are in offline mode or the caller prefers cached values, do not initiate fetch.
         if offline || preferCache {
+            setInitialized()
             completion(.success(cachedEntry))
             return
         }
@@ -231,12 +275,12 @@ class ConfigService {
             cachedEntry = cachedEntry.withFetchTime(time: Date())
             writeCache(entry: cachedEntry)
             callCompletions(result: .success(cachedEntry))
-        case .failure(let error, let isTransient):
+        case .failure(let error, let errorCode, let isTransient):
             if !isTransient && !cachedEntry.isEmpty {
                 cachedEntry = cachedEntry.withFetchTime(time: Date())
                 writeCache(entry: cachedEntry)
             }
-            callCompletions(result: .failure(error, cachedEntry))
+            callCompletions(result: .failure(error, errorCode, cachedEntry))
         }
         completions = nil
         setInitialized()
@@ -312,7 +356,7 @@ class ConfigService {
         }
     }
     
-    private func determineReadyState() -> ClientReadyState {
+    private func determineReadyState() -> ClientCacheState {
         if cachedEntry.isEmpty {
             return .noFlagData
         }

--- a/Sources/ConfigCat/ConfigService.swift
+++ b/Sources/ConfigCat/ConfigService.swift
@@ -37,7 +37,7 @@ class InMemoryResult {
     /** No error occurred (the refresh operation was successful). */
     case none = 0
     /**
-     The refresh operation failed because the client is configured to use the `OverrideBehaviour.LocalOnly` override behavior,
+     The refresh operation failed because the client is configured to use the `OverrideBehaviour.localOnly` override behavior,
      which prevents synchronization with the external cache and making HTTP requests.
      */
     case localOnlyClient = 1

--- a/Sources/ConfigCat/EvaluationDetails.swift
+++ b/Sources/ConfigCat/EvaluationDetails.swift
@@ -206,46 +206,30 @@ public final class TypedEvaluationDetails<Value>: EvaluationDetailsBase {
     public let value: Value
 
     init(
-        key: String,
         value: Value,
-        variationId: String?,
-        fetchTime: Date = Date.distantPast,
-        user: ConfigCatUser? = nil,
-        isDefaultValue: Bool = false,
-        errorCode: EvaluationErrorCode,
-        error: String? = nil,
-        matchedTargetingRule: TargetingRule? = nil,
-        matchedPercentageOption: PercentageOption? = nil
+        details: EvaluationDetails
     ) {
         self.value = value
         super.init(
-            key: key,
-            variationId: variationId,
-            fetchTime: fetchTime,
-            user: user,
-            isDefaultValue: isDefaultValue,
-            errorCode: errorCode,
-            error: error,
-            matchedTargetingRule: matchedTargetingRule,
-            matchedPercentageOption: matchedPercentageOption
+            key: details.key,
+            variationId: details.variationId,
+            fetchTime: details.fetchTime,
+            user: details.user,
+            isDefaultValue: details.isDefaultValue,
+            errorCode: details.errorCode,
+            error: details.error,
+            matchedTargetingRule: details.matchedTargetingRule,
+            matchedPercentageOption: details.matchedPercentageOption
         )
     }
 
     static func fromError(
-        key: String,
         value: Value,
-        error: String,
-        errorCode: EvaluationErrorCode,
-        user: ConfigCatUser?
+        details: EvaluationDetails
     ) -> TypedEvaluationDetails<Value> {
         TypedEvaluationDetails<Value>(
-            key: key,
             value: value,
-            variationId: "",
-            user: user,
-            isDefaultValue: true,
-            errorCode: errorCode,
-            error: error
+            details: details
         )
     }
 

--- a/Sources/ConfigCat/EvaluationDetails.swift
+++ b/Sources/ConfigCat/EvaluationDetails.swift
@@ -38,16 +38,16 @@ public class EvaluationDetailsBase: NSObject {
     /// The percentage option (if any) that was used to select the evaluated value.
     @objc public let matchedPercentageOption: PercentageOption?
 
-    init(
+    fileprivate init(
         key: String,
         variationId: String?,
-        fetchTime: Date = Date.distantPast,
-        user: ConfigCatUser? = nil,
-        isDefaultValue: Bool = false,
+        fetchTime: Date,
+        user: ConfigCatUser?,
+        isDefaultValue: Bool,
         errorCode: EvaluationErrorCode,
-        error: String? = nil,
-        matchedTargetingRule: TargetingRule? = nil,
-        matchedPercentageOption: PercentageOption? = nil
+        error: String?,
+        matchedTargetingRule: TargetingRule?,
+        matchedPercentageOption: PercentageOption?
     ) {
         self.key = key
         self.variationId = variationId

--- a/Sources/ConfigCat/EvaluationDetails.swift
+++ b/Sources/ConfigCat/EvaluationDetails.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Specifies the possible evaluation error codes.
 @objc public enum EvaluationErrorCode: Int {
-    /** Invalid user input was set on an evaluation request. */
+    /** Invalid arguments were passed to the evaluation method. */
     case invalidUserInput = -2
     /** An unexpected error occurred during the evaluation. */
     case unexpectedError = -1

--- a/Sources/ConfigCat/EvaluationDetails.swift
+++ b/Sources/ConfigCat/EvaluationDetails.swift
@@ -2,6 +2,8 @@ import Foundation
 
 /// Specifies the possible evaluation error codes.
 @objc public enum EvaluationErrorCode: Int {
+    /** Invalid user input was set on an evaluation request. */
+    case invalidUserInput = -2
     /** An unexpected error occurred during the evaluation. */
     case unexpectedError = -1
     /** No error occurred (the evaluation was successful). */

--- a/Sources/ConfigCat/EvaluationDetails.swift
+++ b/Sources/ConfigCat/EvaluationDetails.swift
@@ -1,5 +1,21 @@
 import Foundation
 
+/// Specifies the possible evaluation error codes.
+@objc public enum EvaluationErrorCode: Int {
+    /** An unexpected error occurred during the evaluation. */
+    case unexpectedError = -1
+    /** No error occurred (the evaluation was successful). */
+    case none = 0
+    /** The evaluation failed because of an error in the config model. (Most likely, invalid data was passed to the SDK via flag overrides.) */
+    case invalidConfigModel = 1
+    /** The evaluation failed because of a type mismatch between the evaluated setting value and the specified default value. */
+    case settingValueTypeMismatch = 2
+    /** The evaluation failed because the config JSON was not available locally. */
+    case configJsonNotAvailable = 1000
+    /** The evaluation failed because the key of the evaluated setting was not found in the config JSON. */
+    case settingKeyMissing = 1001
+}
+
 public class EvaluationDetailsBase: NSObject {
     /// Key of the feature flag or setting.
     @objc public let key: String
@@ -11,6 +27,8 @@ public class EvaluationDetailsBase: NSObject {
     @objc public let isDefaultValue: Bool
     /// Error message in case evaluation failed.
     @objc public let error: String?
+    /// The code identifying the reason for the error in case evaluation failed.
+    @objc public let errorCode: EvaluationErrorCode
     /// Time of last successful config download.
     @objc public let fetchTime: Date
     /// The targeting rule (if any) that matched during the evaluation and was used to return the evaluated value.
@@ -18,19 +36,23 @@ public class EvaluationDetailsBase: NSObject {
     /// The percentage option (if any) that was used to select the evaluated value.
     @objc public let matchedPercentageOption: PercentageOption?
 
-    init(key: String,
-         variationId: String?,
-         fetchTime: Date = Date.distantPast,
-         user: ConfigCatUser? = nil,
-         isDefaultValue: Bool = false,
-         error: String? = nil,
-         matchedTargetingRule: TargetingRule? = nil,
-         matchedPercentageOption: PercentageOption? = nil) {
+    init(
+        key: String,
+        variationId: String?,
+        fetchTime: Date = Date.distantPast,
+        user: ConfigCatUser? = nil,
+        isDefaultValue: Bool = false,
+        errorCode: EvaluationErrorCode,
+        error: String? = nil,
+        matchedTargetingRule: TargetingRule? = nil,
+        matchedPercentageOption: PercentageOption? = nil
+    ) {
         self.key = key
         self.variationId = variationId
         self.user = user
         self.fetchTime = fetchTime
         self.isDefaultValue = isDefaultValue
+        self.errorCode = errorCode
         self.error = error
         self.matchedTargetingRule = matchedTargetingRule
         self.matchedPercentageOption = matchedPercentageOption
@@ -40,21 +62,48 @@ public class EvaluationDetailsBase: NSObject {
 public final class EvaluationDetails: EvaluationDetailsBase {
     @objc public let value: Any
 
-    init(key: String,
-         value: Any,
-         variationId: String?,
-         fetchTime: Date = Date.distantPast,
-         user: ConfigCatUser? = nil,
-         isDefaultValue: Bool = false,
-         error: String? = nil,
-         matchedTargetingRule: TargetingRule? = nil,
-         matchedPercentageOption: PercentageOption? = nil) {
+    init(
+        key: String,
+        value: Any,
+        variationId: String?,
+        fetchTime: Date = Date.distantPast,
+        user: ConfigCatUser? = nil,
+        isDefaultValue: Bool = false,
+        errorCode: EvaluationErrorCode,
+        error: String? = nil,
+        matchedTargetingRule: TargetingRule? = nil,
+        matchedPercentageOption: PercentageOption? = nil
+    ) {
         self.value = value
-        super.init(key: key, variationId: variationId, fetchTime: fetchTime, user: user, isDefaultValue: isDefaultValue, error: error, matchedTargetingRule: matchedTargetingRule, matchedPercentageOption: matchedPercentageOption)
+        super.init(
+            key: key,
+            variationId: variationId,
+            fetchTime: fetchTime,
+            user: user,
+            isDefaultValue: isDefaultValue,
+            errorCode: errorCode,
+            error: error,
+            matchedTargetingRule: matchedTargetingRule,
+            matchedPercentageOption: matchedPercentageOption
+        )
     }
 
-    static func fromError(key: String, value: Any, error: String, user: ConfigCatUser?) -> EvaluationDetails {
-        EvaluationDetails(key: key, value: value, variationId: "", user: user, isDefaultValue: true, error: error)
+    static func fromError(
+        key: String,
+        value: Any,
+        error: String,
+        errorCode: EvaluationErrorCode,
+        user: ConfigCatUser?
+    ) -> EvaluationDetails {
+        EvaluationDetails(
+            key: key,
+            value: value,
+            variationId: "",
+            user: user,
+            isDefaultValue: true,
+            errorCode: errorCode,
+            error: error
+        )
     }
 }
 
@@ -62,10 +111,22 @@ public final class StringEvaluationDetails: EvaluationDetailsBase {
     /// Evaluated value of the feature flag or setting.
     @objc public let value: String
 
-    init(value: String,
-         base: EvaluationDetailsBase) {
+    init(
+        value: String,
+        base: EvaluationDetailsBase
+    ) {
         self.value = value
-        super.init(key: base.key, variationId: base.variationId, fetchTime: base.fetchTime, user: base.user, isDefaultValue: base.isDefaultValue, error: base.error, matchedTargetingRule: base.matchedTargetingRule, matchedPercentageOption: base.matchedPercentageOption)
+        super.init(
+            key: base.key,
+            variationId: base.variationId,
+            fetchTime: base.fetchTime,
+            user: base.user,
+            isDefaultValue: base.isDefaultValue,
+            errorCode: base.errorCode,
+            error: base.error,
+            matchedTargetingRule: base.matchedTargetingRule,
+            matchedPercentageOption: base.matchedPercentageOption
+        )
     }
 }
 
@@ -73,10 +134,22 @@ public final class BoolEvaluationDetails: EvaluationDetailsBase {
     /// Evaluated value of the feature flag or setting.
     @objc public let value: Bool
 
-    init(value: Bool,
-         base: EvaluationDetailsBase) {
+    init(
+        value: Bool,
+        base: EvaluationDetailsBase
+    ) {
         self.value = value
-        super.init(key: base.key, variationId: base.variationId, fetchTime: base.fetchTime, user: base.user, isDefaultValue: base.isDefaultValue, error: base.error, matchedTargetingRule: base.matchedTargetingRule, matchedPercentageOption: base.matchedPercentageOption)
+        super.init(
+            key: base.key,
+            variationId: base.variationId,
+            fetchTime: base.fetchTime,
+            user: base.user,
+            isDefaultValue: base.isDefaultValue,
+            errorCode: base.errorCode,
+            error: base.error,
+            matchedTargetingRule: base.matchedTargetingRule,
+            matchedPercentageOption: base.matchedPercentageOption
+        )
     }
 }
 
@@ -84,10 +157,22 @@ public final class IntEvaluationDetails: EvaluationDetailsBase {
     /// Evaluated value of the feature flag or setting.
     @objc public let value: Int
 
-    init(value: Int,
-         base: EvaluationDetailsBase) {
+    init(
+        value: Int,
+        base: EvaluationDetailsBase
+    ) {
         self.value = value
-        super.init(key: base.key, variationId: base.variationId, fetchTime: base.fetchTime, user: base.user, isDefaultValue: base.isDefaultValue, error: base.error, matchedTargetingRule: base.matchedTargetingRule, matchedPercentageOption: base.matchedPercentageOption)
+        super.init(
+            key: base.key,
+            variationId: base.variationId,
+            fetchTime: base.fetchTime,
+            user: base.user,
+            isDefaultValue: base.isDefaultValue,
+            errorCode: base.errorCode,
+            error: base.error,
+            matchedTargetingRule: base.matchedTargetingRule,
+            matchedPercentageOption: base.matchedPercentageOption
+        )
     }
 }
 
@@ -95,10 +180,22 @@ public final class DoubleEvaluationDetails: EvaluationDetailsBase {
     /// Evaluated value of the feature flag or setting.
     @objc public let value: Double
 
-    init(value: Double,
-         base: EvaluationDetailsBase) {
+    init(
+        value: Double,
+        base: EvaluationDetailsBase
+    ) {
         self.value = value
-        super.init(key: base.key, variationId: base.variationId, fetchTime: base.fetchTime, user: base.user, isDefaultValue: base.isDefaultValue, error: base.error, matchedTargetingRule: base.matchedTargetingRule, matchedPercentageOption: base.matchedPercentageOption)
+        super.init(
+            key: base.key,
+            variationId: base.variationId,
+            fetchTime: base.fetchTime,
+            user: base.user,
+            isDefaultValue: base.isDefaultValue,
+            errorCode: base.errorCode,
+            error: base.error,
+            matchedTargetingRule: base.matchedTargetingRule,
+            matchedPercentageOption: base.matchedPercentageOption
+        )
     }
 }
 
@@ -106,21 +203,48 @@ public final class TypedEvaluationDetails<Value>: EvaluationDetailsBase {
     /// Evaluated value of the feature flag or setting.
     public let value: Value
 
-    init(key: String,
-         value: Value,
-         variationId: String?,
-         fetchTime: Date = Date.distantPast,
-         user: ConfigCatUser? = nil,
-         isDefaultValue: Bool = false,
-         error: String? = nil,
-         matchedTargetingRule: TargetingRule? = nil,
-         matchedPercentageOption: PercentageOption? = nil) {
+    init(
+        key: String,
+        value: Value,
+        variationId: String?,
+        fetchTime: Date = Date.distantPast,
+        user: ConfigCatUser? = nil,
+        isDefaultValue: Bool = false,
+        errorCode: EvaluationErrorCode,
+        error: String? = nil,
+        matchedTargetingRule: TargetingRule? = nil,
+        matchedPercentageOption: PercentageOption? = nil
+    ) {
         self.value = value
-        super.init(key: key, variationId: variationId, fetchTime: fetchTime, user: user, isDefaultValue: isDefaultValue, error: error, matchedTargetingRule: matchedTargetingRule, matchedPercentageOption: matchedPercentageOption)
+        super.init(
+            key: key,
+            variationId: variationId,
+            fetchTime: fetchTime,
+            user: user,
+            isDefaultValue: isDefaultValue,
+            errorCode: errorCode,
+            error: error,
+            matchedTargetingRule: matchedTargetingRule,
+            matchedPercentageOption: matchedPercentageOption
+        )
     }
 
-    static func fromError(key: String, value: Value, error: String, user: ConfigCatUser?) -> TypedEvaluationDetails<Value> {
-        TypedEvaluationDetails<Value>(key: key, value: value, variationId: "", user: user, isDefaultValue: true, error: error)
+    static func fromError(
+        key: String,
+        value: Value,
+        error: String,
+        errorCode: EvaluationErrorCode,
+        user: ConfigCatUser?
+    ) -> TypedEvaluationDetails<Value> {
+        TypedEvaluationDetails<Value>(
+            key: key,
+            value: value,
+            variationId: "",
+            user: user,
+            isDefaultValue: true,
+            errorCode: errorCode,
+            error: error
+        )
     }
 
     func toStringDetails() -> StringEvaluationDetails {

--- a/Sources/ConfigCat/Extensions.swift
+++ b/Sources/ConfigCat/Extensions.swift
@@ -1,196 +1,362 @@
 import Foundation
 
 extension ConfigCatClient {
-    @objc public func getStringValue(for key: String, defaultValue: String, user: ConfigCatUser?, completion: @escaping (String) -> ()) {
-        return getValue(for: key, defaultValue: defaultValue, user: user, completion: completion)
+    @objc public func getStringValue(
+        for key: String,
+        defaultValue: String,
+        user: ConfigCatUser?,
+        completion: @escaping (String) -> Void
+    ) {
+        return getValue(
+            for: key,
+            defaultValue: defaultValue,
+            user: user,
+            completion: completion
+        )
     }
 
-    @objc public func getIntValue(for key: String, defaultValue: Int, user: ConfigCatUser?, completion: @escaping (Int) -> ()) {
-        return getValue(for: key, defaultValue: defaultValue, user: user, completion: completion)
+    @objc public func getIntValue(
+        for key: String,
+        defaultValue: Int,
+        user: ConfigCatUser?,
+        completion: @escaping (Int) -> Void
+    ) {
+        return getValue(
+            for: key,
+            defaultValue: defaultValue,
+            user: user,
+            completion: completion
+        )
     }
 
-    @objc public func getDoubleValue(for key: String, defaultValue: Double, user: ConfigCatUser?, completion: @escaping (Double) -> ()) {
-        return getValue(for: key, defaultValue: defaultValue, user: user, completion: completion)
+    @objc public func getDoubleValue(
+        for key: String,
+        defaultValue: Double,
+        user: ConfigCatUser?,
+        completion: @escaping (Double) -> Void
+    ) {
+        return getValue(
+            for: key,
+            defaultValue: defaultValue,
+            user: user,
+            completion: completion
+        )
     }
 
-    @objc public func getBoolValue(for key: String, defaultValue: Bool, user: ConfigCatUser?, completion: @escaping (Bool) -> ()) {
-        return getValue(for: key, defaultValue: defaultValue, user: user, completion: completion)
+    @objc public func getBoolValue(
+        for key: String,
+        defaultValue: Bool,
+        user: ConfigCatUser?,
+        completion: @escaping (Bool) -> Void
+    ) {
+        return getValue(
+            for: key,
+            defaultValue: defaultValue,
+            user: user,
+            completion: completion
+        )
     }
 
-    @objc public func getAnyValue(for key: String, defaultValue: Any, user: ConfigCatUser?, completion: @escaping (Any) -> ()) {
-        return getValue(for: key, defaultValue: defaultValue, user: user, completion: completion)
+    @objc public func getAnyValue(
+        for key: String,
+        defaultValue: Any,
+        user: ConfigCatUser?,
+        completion: @escaping (Any) -> Void
+    ) {
+        return getValue(
+            for: key,
+            defaultValue: defaultValue,
+            user: user,
+            completion: completion
+        )
     }
 
-    @objc public func getAnyValueDetails(for key: String, defaultValue: Any, user: ConfigCatUser?, completion: @escaping (EvaluationDetails) -> ()) {
-        return getValueDetails(for: key, defaultValue: defaultValue, user: user) { details in
-            completion(EvaluationDetails(key: details.key,
+    @objc public func getAnyValueDetails(
+        for key: String,
+        defaultValue: Any,
+        user: ConfigCatUser?,
+        completion: @escaping (EvaluationDetails) -> Void
+    ) {
+        return getValueDetails(for: key, defaultValue: defaultValue, user: user)
+        { details in
+            completion(
+                EvaluationDetails(
+                    key: details.key,
                     value: details.value,
                     variationId: details.variationId,
                     fetchTime: details.fetchTime,
                     user: user,
                     isDefaultValue: details.isDefaultValue,
+                    errorCode: details.errorCode,
                     error: details.error,
                     matchedTargetingRule: details.matchedTargetingRule,
-                    matchedPercentageOption: details.matchedPercentageOption))
+                    matchedPercentageOption: details.matchedPercentageOption
+                )
+            )
         }
     }
 
-    @objc public func getStringValueDetails(for key: String, defaultValue: String, user: ConfigCatUser?, completion: @escaping (StringEvaluationDetails) -> ()) {
-        return getValueDetails(for: key, defaultValue: defaultValue, user: user) { details in
+    @objc public func getStringValueDetails(
+        for key: String,
+        defaultValue: String,
+        user: ConfigCatUser?,
+        completion: @escaping (StringEvaluationDetails) -> Void
+    ) {
+        return getValueDetails(for: key, defaultValue: defaultValue, user: user)
+        { details in
             completion(details.toStringDetails())
         }
     }
 
-    @objc public func getBoolValueDetails(for key: String, defaultValue: Bool, user: ConfigCatUser?, completion: @escaping (BoolEvaluationDetails) -> ()) {
-        return getValueDetails(for: key, defaultValue: defaultValue, user: user) { details in
+    @objc public func getBoolValueDetails(
+        for key: String,
+        defaultValue: Bool,
+        user: ConfigCatUser?,
+        completion: @escaping (BoolEvaluationDetails) -> Void
+    ) {
+        return getValueDetails(for: key, defaultValue: defaultValue, user: user)
+        { details in
             completion(details.toBoolDetails())
         }
     }
 
-    @objc public func getIntValueDetails(for key: String, defaultValue: Int, user: ConfigCatUser?, completion: @escaping (IntEvaluationDetails) -> ()) {
-        return getValueDetails(for: key, defaultValue: defaultValue, user: user) { details in
+    @objc public func getIntValueDetails(
+        for key: String,
+        defaultValue: Int,
+        user: ConfigCatUser?,
+        completion: @escaping (IntEvaluationDetails) -> Void
+    ) {
+        return getValueDetails(for: key, defaultValue: defaultValue, user: user)
+        { details in
             completion(details.toIntDetails())
         }
     }
 
-    @objc public func getDoubleValueDetails(for key: String, defaultValue: Double, user: ConfigCatUser?, completion: @escaping (DoubleEvaluationDetails) -> ()) {
-        return getValueDetails(for: key, defaultValue: defaultValue, user: user) { details in
+    @objc public func getDoubleValueDetails(
+        for key: String,
+        defaultValue: Double,
+        user: ConfigCatUser?,
+        completion: @escaping (DoubleEvaluationDetails) -> Void
+    ) {
+        return getValueDetails(for: key, defaultValue: defaultValue, user: user)
+        { details in
             completion(details.toDoubleDetails())
         }
     }
 
     #if compiler(>=5.5) && canImport(_Concurrency)
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    public func getValue<Value>(for key: String, defaultValue: Value, user: ConfigCatUser? = nil) async -> Value {
-        await withUnsafeContinuation { continuation in
-            getValue(for: key, defaultValue: defaultValue, user: user) { value in
-                continuation.resume(returning: value)
+        @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+        public func getValue<Value>(
+            for key: String,
+            defaultValue: Value,
+            user: ConfigCatUser? = nil
+        ) async -> Value {
+            await withUnsafeContinuation { continuation in
+                getValue(for: key, defaultValue: defaultValue, user: user) {
+                    value in
+                    continuation.resume(returning: value)
+                }
             }
         }
-    }
-    
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    public func getAnyValue(for key: String, defaultValue: Any?, user: ConfigCatUser? = nil) async -> Any? {
-        await withUnsafeContinuation { continuation in
-            getValue(for: key, defaultValue: defaultValue, user: user) { value in
-                continuation.resume(returning: value)
-            }
-        }
-    }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    public func getValueDetails<Value>(for key: String, defaultValue: Value, user: ConfigCatUser? = nil) async -> TypedEvaluationDetails<Value> {
-        await withUnsafeContinuation { continuation in
-            getValueDetails(for: key, defaultValue: defaultValue, user: user) { details in
-                continuation.resume(returning: details)
+        @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+        public func getAnyValue(
+            for key: String,
+            defaultValue: Any?,
+            user: ConfigCatUser? = nil
+        ) async -> Any? {
+            await withUnsafeContinuation { continuation in
+                getValue(for: key, defaultValue: defaultValue, user: user) {
+                    value in
+                    continuation.resume(returning: value)
+                }
             }
         }
-    }
-    
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    public func getAnyValueDetails(for key: String, defaultValue: Any?, user: ConfigCatUser? = nil) async -> TypedEvaluationDetails<Any?> {
-        await withUnsafeContinuation { continuation in
-            getValueDetails(for: key, defaultValue: defaultValue, user: user) { details in
-                continuation.resume(returning: details)
-            }
-        }
-    }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    public func getAllValueDetails(user: ConfigCatUser? = nil) async -> [EvaluationDetails] {
-        await withUnsafeContinuation { continuation in
-            getAllValueDetails(user: user) { details in
-                continuation.resume(returning: details)
+        @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+        public func getValueDetails<Value>(
+            for key: String,
+            defaultValue: Value,
+            user: ConfigCatUser? = nil
+        ) async -> TypedEvaluationDetails<Value> {
+            await withUnsafeContinuation { continuation in
+                getValueDetails(
+                    for: key,
+                    defaultValue: defaultValue,
+                    user: user
+                ) { details in
+                    continuation.resume(returning: details)
+                }
             }
         }
-    }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    public func getAllKeys() async -> [String] {
-        await withUnsafeContinuation { continuation in
-            getAllKeys { keys in
-                continuation.resume(returning: keys)
+        @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+        public func getAnyValueDetails(
+            for key: String,
+            defaultValue: Any?,
+            user: ConfigCatUser? = nil
+        ) async -> TypedEvaluationDetails<Any?> {
+            await withUnsafeContinuation { continuation in
+                getValueDetails(
+                    for: key,
+                    defaultValue: defaultValue,
+                    user: user
+                ) { details in
+                    continuation.resume(returning: details)
+                }
             }
         }
-    }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    public func getKeyAndValue(for variationId: String) async -> KeyValue? {
-        await withUnsafeContinuation { continuation in
-            getKeyAndValue(for: variationId) { value in
-                continuation.resume(returning: value)
+        @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+        public func getAllValueDetails(user: ConfigCatUser? = nil) async
+            -> [EvaluationDetails]
+        {
+            await withUnsafeContinuation { continuation in
+                getAllValueDetails(user: user) { details in
+                    continuation.resume(returning: details)
+                }
             }
         }
-    }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    public func getAllValues(user: ConfigCatUser? = nil) async -> [String: Any] {
-        await withUnsafeContinuation { continuation in
-            getAllValues(user: user) { values in
-                continuation.resume(returning: values)
+        @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+        public func getAllKeys() async -> [String] {
+            await withUnsafeContinuation { continuation in
+                getAllKeys { keys in
+                    continuation.resume(returning: keys)
+                }
             }
         }
-    }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-    @discardableResult
-    public func forceRefresh() async -> RefreshResult {
-        await withUnsafeContinuation { continuation in
-            forceRefresh { result in
-                continuation.resume(returning: result)
+        @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+        public func getKeyAndValue(for variationId: String) async -> KeyValue? {
+            await withUnsafeContinuation { continuation in
+                getKeyAndValue(for: variationId) { value in
+                    continuation.resume(returning: value)
+                }
             }
         }
-    }
+
+        @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+        public func getAllValues(user: ConfigCatUser? = nil) async -> [String:
+            Any]
+        {
+            await withUnsafeContinuation { continuation in
+                getAllValues(user: user) { values in
+                    continuation.resume(returning: values)
+                }
+            }
+        }
+
+        @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+        @discardableResult
+        public func forceRefresh() async -> RefreshResult {
+            await withUnsafeContinuation { continuation in
+                forceRefresh { result in
+                    continuation.resume(returning: result)
+                }
+            }
+        }
     #endif
 }
 
-extension ConfigCatSnapshot {
-    @objc public func getStringValue(for key: String, defaultValue: String, user: ConfigCatUser?) -> String {
+extension ConfigCatClientSnapshot {
+    @objc public func getStringValue(
+        for key: String,
+        defaultValue: String,
+        user: ConfigCatUser?
+    ) -> String {
         return getValue(for: key, defaultValue: defaultValue, user: user)
     }
 
-    @objc public func getIntValue(for key: String, defaultValue: Int, user: ConfigCatUser?) -> Int {
+    @objc public func getIntValue(
+        for key: String,
+        defaultValue: Int,
+        user: ConfigCatUser?
+    ) -> Int {
         return getValue(for: key, defaultValue: defaultValue, user: user)
     }
 
-    @objc public func getDoubleValue(for key: String, defaultValue: Double, user: ConfigCatUser?) -> Double {
+    @objc public func getDoubleValue(
+        for key: String,
+        defaultValue: Double,
+        user: ConfigCatUser?
+    ) -> Double {
         return getValue(for: key, defaultValue: defaultValue, user: user)
     }
 
-    @objc public func getBoolValue(for key: String, defaultValue: Bool, user: ConfigCatUser?) -> Bool {
+    @objc public func getBoolValue(
+        for key: String,
+        defaultValue: Bool,
+        user: ConfigCatUser?
+    ) -> Bool {
         return getValue(for: key, defaultValue: defaultValue, user: user)
     }
 
-    @objc public func getAnyValue(for key: String, defaultValue: Any, user: ConfigCatUser?) -> Any {
+    @objc public func getAnyValue(
+        for key: String,
+        defaultValue: Any,
+        user: ConfigCatUser?
+    ) -> Any {
         return getValue(for: key, defaultValue: defaultValue, user: user)
     }
 
-    @objc public func getAnyValueDetails(for key: String, defaultValue: Any, user: ConfigCatUser?) -> EvaluationDetails {
-        let details = getValueDetails(for: key, defaultValue: defaultValue, user: user)
-        return EvaluationDetails(key: details.key,
-                                 value: details.value,
-                                 variationId: details.variationId,
-                                 fetchTime: details.fetchTime,
-                                 user: user,
-                                 isDefaultValue: details.isDefaultValue,
-                                 error: details.error,
-                                 matchedTargetingRule: details.matchedTargetingRule,
-                                 matchedPercentageOption: details.matchedPercentageOption)
+    @objc public func getAnyValueDetails(
+        for key: String,
+        defaultValue: Any,
+        user: ConfigCatUser?
+    ) -> EvaluationDetails {
+        let details = getValueDetails(
+            for: key,
+            defaultValue: defaultValue,
+            user: user
+        )
+        return EvaluationDetails(
+            key: details.key,
+            value: details.value,
+            variationId: details.variationId,
+            fetchTime: details.fetchTime,
+            user: user,
+            isDefaultValue: details.isDefaultValue,
+            errorCode: details.errorCode,
+            error: details.error,
+            matchedTargetingRule: details.matchedTargetingRule,
+            matchedPercentageOption: details.matchedPercentageOption
+        )
     }
 
-    @objc public func getStringValueDetails(for key: String, defaultValue: String, user: ConfigCatUser?) -> StringEvaluationDetails {
-        return getValueDetails(for: key, defaultValue: defaultValue, user: user).toStringDetails()
+    @objc public func getStringValueDetails(
+        for key: String,
+        defaultValue: String,
+        user: ConfigCatUser?
+    ) -> StringEvaluationDetails {
+        return getValueDetails(for: key, defaultValue: defaultValue, user: user)
+            .toStringDetails()
     }
 
-    @objc public func getBoolValueDetails(for key: String, defaultValue: Bool, user: ConfigCatUser?) -> BoolEvaluationDetails {
-        return getValueDetails(for: key, defaultValue: defaultValue, user: user).toBoolDetails()
+    @objc public func getBoolValueDetails(
+        for key: String,
+        defaultValue: Bool,
+        user: ConfigCatUser?
+    ) -> BoolEvaluationDetails {
+        return getValueDetails(for: key, defaultValue: defaultValue, user: user)
+            .toBoolDetails()
     }
 
-    @objc public func getIntValueDetails(for key: String, defaultValue: Int, user: ConfigCatUser?) -> IntEvaluationDetails {
-        return getValueDetails(for: key, defaultValue: defaultValue, user: user).toIntDetails()
+    @objc public func getIntValueDetails(
+        for key: String,
+        defaultValue: Int,
+        user: ConfigCatUser?
+    ) -> IntEvaluationDetails {
+        return getValueDetails(for: key, defaultValue: defaultValue, user: user)
+            .toIntDetails()
     }
 
-    @objc public func getDoubleValueDetails(for key: String, defaultValue: Double, user: ConfigCatUser?) -> DoubleEvaluationDetails {
-        return getValueDetails(for: key, defaultValue: defaultValue, user: user).toDoubleDetails()
+    @objc public func getDoubleValueDetails(
+        for key: String,
+        defaultValue: Double,
+        user: ConfigCatUser?
+    ) -> DoubleEvaluationDetails {
+        return getValueDetails(for: key, defaultValue: defaultValue, user: user)
+            .toDoubleDetails()
     }
 }

--- a/Sources/ConfigCat/FlagEvaluator.swift
+++ b/Sources/ConfigCat/FlagEvaluator.swift
@@ -4,108 +4,203 @@ class FlagEvaluator {
     private let log: InternalLogger
     private let evaluator: RolloutEvaluator
     private let hooks: Hooks
-    
+
     init(log: InternalLogger, evaluator: RolloutEvaluator, hooks: Hooks) {
         self.log = log
         self.evaluator = evaluator
         self.hooks = hooks
     }
-    
-    func validateFlagType<Value>(of: Value.Type, key: String, defaultValue: Any, user: ConfigCatUser?) -> String? {
-        if of != String.self &&
-            of != String?.self &&
-            of != Int.self &&
-            of != Int?.self &&
-            of != Double.self &&
-            of != Double?.self &&
-            of != Bool.self &&
-            of != Bool?.self &&
-            of != Any.self &&
-            of != Any?.self {
-            let message = "Only the following types are supported: String, Int, Double, Bool, and Any (both nullable and non-nullable)."
+
+    func validateFlagType<Value>(
+        of: Value.Type,
+        key: String,
+        defaultValue: Any,
+        user: ConfigCatUser?
+    ) -> String? {
+        if of != String.self && of != String?.self && of != Int.self
+            && of != Int?.self && of != Double.self && of != Double?.self
+            && of != Bool.self && of != Bool?.self && of != Any.self
+            && of != Any?.self
+        {
+            let message =
+                "Only the following types are supported: String, Int, Double, Bool, and Any (both nullable and non-nullable)."
             log.error(eventId: 2022, message: message)
-            hooks.invokeOnFlagEvaluated(details: EvaluationDetails.fromError(key: key,
+            hooks.invokeOnFlagEvaluated(
+                details: EvaluationDetails.fromError(
+                    key: key,
                     value: defaultValue,
                     error: message,
-                    user: user))
+                    errorCode: .settingValueTypeMismatch,
+                    user: user
+                )
+            )
             return message
         }
-        
+
         return nil
     }
-    
-    func evaluateFlag<Value>(result: SettingsResult, key: String, defaultValue: Value, user: ConfigCatUser?) -> TypedEvaluationDetails<Value> {
+
+    func evaluateFlag<Value>(
+        result: SettingsResult,
+        key: String,
+        defaultValue: Value,
+        user: ConfigCatUser?
+    ) -> TypedEvaluationDetails<Value> {
         if result.settings.isEmpty {
-            let message = String(format: "Config JSON is not present when evaluating setting '%@'. Returning the `defaultValue` parameter that you specified in your application: '%@'.",
-                key, "\(defaultValue)")
+            let message = String(
+                format:
+                    "Config JSON is not present when evaluating setting '%@'. Returning the `defaultValue` parameter that you specified in your application: '%@'.",
+                key,
+                "\(defaultValue)"
+            )
             self.log.error(eventId: 1000, message: message)
-            self.hooks.invokeOnFlagEvaluated(details: EvaluationDetails.fromError(key: key,
-                                                                                  value: defaultValue,
-                                                                                  error: message,
-                                                                                  user: user))
-            return TypedEvaluationDetails<Value>.fromError(key: key, value: defaultValue, error: message, user: user)
+            self.hooks.invokeOnFlagEvaluated(
+                details: EvaluationDetails.fromError(
+                    key: key,
+                    value: defaultValue,
+                    error: message,
+                    errorCode: .configJsonNotAvailable,
+                    user: user
+                )
+            )
+            return TypedEvaluationDetails<Value>.fromError(
+                key: key,
+                value: defaultValue,
+                error: message,
+                errorCode: .configJsonNotAvailable,
+                user: user
+            )
         }
         guard let setting = result.settings[key] else {
-            let message = String(format: "Failed to evaluate setting '%@' (the key was not found in config JSON). "
-                                 + "Returning the `defaultValue` parameter that you specified in your application: '%@'. Available keys: [%@].", key, "\(defaultValue)", result.settings.keys.map { key in
-                return "'"+key+"'"
-            }.joined(separator: ", "))
+            let message = String(
+                format:
+                    "Failed to evaluate setting '%@' (the key was not found in config JSON). "
+                    + "Returning the `defaultValue` parameter that you specified in your application: '%@'. Available keys: [%@].",
+                key,
+                "\(defaultValue)",
+                result.settings.keys.map { key in
+                    return "'" + key + "'"
+                }.joined(separator: ", ")
+            )
             self.log.error(eventId: 1001, message: message)
-            self.hooks.invokeOnFlagEvaluated(details: EvaluationDetails.fromError(key: key,
-                                                                                  value: defaultValue,
-                                                                                  error: message,
-                                                                                  user: user))
-            return TypedEvaluationDetails<Value>.fromError(key: key, value: defaultValue, error: message, user: user)
+            self.hooks.invokeOnFlagEvaluated(
+                details: EvaluationDetails.fromError(
+                    key: key,
+                    value: defaultValue,
+                    error: message,
+                    errorCode: .settingKeyMissing,
+                    user: user
+                )
+            )
+            return TypedEvaluationDetails<Value>.fromError(
+                key: key,
+                value: defaultValue,
+                error: message,
+                errorCode: .settingKeyMissing,
+                user: user
+            )
         }
-        let evaluationResult = evaluator.evaluate(setting: setting, key: key, user: user, settings: result.settings, defaultValue: defaultValue)
+        let evaluationResult = evaluator.evaluate(
+            setting: setting,
+            key: key,
+            user: user,
+            settings: result.settings,
+            defaultValue: defaultValue
+        )
         switch evaluationResult {
         case .success(let value, let variationId, let rule, let option):
             guard let typedValue = value as? Value else {
-                let message = "The type of a setting must match the type of the specified default value. Setting's type was \(setting.settingType.text) but the default value's type was \(Value.self). Please use a default value which corresponds to the setting type \(setting.settingType.text). Learn more: https://configcat.com/docs/sdk-reference/ios/#setting-type-mapping"
+                let message =
+                    "The type of a setting must match the type of the specified default value. Setting's type was \(setting.settingType.text) but the default value's type was \(Value.self). Please use a default value which corresponds to the setting type \(setting.settingType.text). Learn more: https://configcat.com/docs/sdk-reference/ios/#setting-type-mapping"
                 self.log.error(eventId: 2002, message: message)
-                self.hooks.invokeOnFlagEvaluated(details: EvaluationDetails.fromError(key: key,
-                                                                                      value: defaultValue,
-                                                                                      error: message,
-                                                                                      user: user))
-                return TypedEvaluationDetails<Value>.fromError(key: key, value: defaultValue, error: message, user: user)
+                self.hooks.invokeOnFlagEvaluated(
+                    details: EvaluationDetails.fromError(
+                        key: key,
+                        value: defaultValue,
+                        error: message,
+                        errorCode: .settingValueTypeMismatch,
+                        user: user
+                    )
+                )
+                return TypedEvaluationDetails<Value>.fromError(
+                    key: key,
+                    value: defaultValue,
+                    error: message,
+                    errorCode: .settingValueTypeMismatch,
+                    user: user
+                )
             }
-            
-            hooks.invokeOnFlagEvaluated(details: EvaluationDetails(key: key,
-                                                                   value: typedValue,
-                                                                   variationId: variationId,
-                                                                   fetchTime: result.fetchTime,
-                                                                   user: user,
-                                                                   matchedTargetingRule: rule,
-                                                                   matchedPercentageOption: option))
-            return TypedEvaluationDetails<Value>(key: key,
-                                                 value: typedValue,
-                                                 variationId: variationId,
-                                                 fetchTime: result.fetchTime,
-                                                 user: user,
-                                                 matchedTargetingRule: rule,
-                                                 matchedPercentageOption: option)
+
+            hooks.invokeOnFlagEvaluated(
+                details: EvaluationDetails(
+                    key: key,
+                    value: typedValue,
+                    variationId: variationId,
+                    fetchTime: result.fetchTime,
+                    user: user,
+                    errorCode: .none,
+                    matchedTargetingRule: rule,
+                    matchedPercentageOption: option
+                )
+            )
+            return TypedEvaluationDetails<Value>(
+                key: key,
+                value: typedValue,
+                variationId: variationId,
+                fetchTime: result.fetchTime,
+                user: user,
+                errorCode: .none,
+                matchedTargetingRule: rule,
+                matchedPercentageOption: option
+            )
         case .error(let err):
             let message = "Failed to evaluate setting '\(key)' (\(err))"
             self.log.error(eventId: 1002, message: message)
-            self.hooks.invokeOnFlagEvaluated(details: EvaluationDetails.fromError(key: key,
-                                                                                  value: defaultValue,
-                                                                                  error: message,
-                                                                                  user: user))
-            return TypedEvaluationDetails<Value>.fromError(key: key, value: defaultValue, error: message, user: user)
+            self.hooks.invokeOnFlagEvaluated(
+                details: EvaluationDetails.fromError(
+                    key: key,
+                    value: defaultValue,
+                    error: message,
+                    errorCode: .invalidConfigModel,
+                    user: user
+                )
+            )
+            return TypedEvaluationDetails<Value>.fromError(
+                key: key,
+                value: defaultValue,
+                error: message,
+                errorCode: .invalidConfigModel,
+                user: user
+            )
         }
     }
-    
-    func evaluateFlag(for setting: Setting, key: String, user: ConfigCatUser?, fetchTime: Date, settings: [String: Setting]) -> EvaluationDetails? {
-        let evaluationResult = evaluator.evaluate(setting: setting, key: key, user: user, settings: settings, defaultValue: nil)
+
+    func evaluateFlag(
+        for setting: Setting,
+        key: String,
+        user: ConfigCatUser?,
+        fetchTime: Date,
+        settings: [String: Setting]
+    ) -> EvaluationDetails? {
+        let evaluationResult = evaluator.evaluate(
+            setting: setting,
+            key: key,
+            user: user,
+            settings: settings,
+            defaultValue: nil
+        )
         switch evaluationResult {
         case .success(let value, let variationId, let rule, let option):
-            let details = EvaluationDetails(key: key,
-                                            value: value,
-                                            variationId: variationId,
-                                            fetchTime: fetchTime,
-                                            user: user,
-                                            matchedTargetingRule: rule,
-                                            matchedPercentageOption: option)
+            let details = EvaluationDetails(
+                key: key,
+                value: value,
+                variationId: variationId,
+                fetchTime: fetchTime,
+                user: user,
+                errorCode: .none,
+                matchedTargetingRule: rule,
+                matchedPercentageOption: option
+            )
             hooks.invokeOnFlagEvaluated(details: details)
             return details
         case .error(let err):

--- a/Sources/ConfigCat/FlagEvaluator.swift
+++ b/Sources/ConfigCat/FlagEvaluator.swift
@@ -30,7 +30,7 @@ class FlagEvaluator {
                     key: key,
                     value: defaultValue,
                     error: message,
-                    errorCode: .settingValueTypeMismatch,
+                    errorCode: .invalidUserInput,
                     user: user
                 )
             )

--- a/Sources/ConfigCat/SnapshotBuilder.swift
+++ b/Sources/ConfigCat/SnapshotBuilder.swift
@@ -1,0 +1,60 @@
+protocol SnapshotBuilderProtocol {
+    func buildSnapshot(inMemoryResult: InMemoryResult?) -> ConfigCatClientSnapshot
+    var defaultUser: ConfigCatUser? { get set }
+}
+
+class SnapshotBuilder: SnapshotBuilderProtocol {
+    private let flagEvaluator: FlagEvaluator
+    @Synced public var defaultUser: ConfigCatUser?
+    private let overrideDataSource: OverrideDataSource?
+    private let log: InternalLogger
+    
+    init(
+        flagEvaluator: FlagEvaluator,
+        defaultUser: ConfigCatUser?,
+        overrideDataSource: OverrideDataSource?,
+        log: InternalLogger
+    ) {
+        self.flagEvaluator = flagEvaluator
+        self.defaultUser = defaultUser
+        self.overrideDataSource = overrideDataSource
+        self.log = log
+    }
+  
+    public func buildSnapshot(inMemoryResult: InMemoryResult?) -> ConfigCatClientSnapshot {
+        let inMemorySettings = calcInMemorySettingsWithOverrides(inMemoryResult: inMemoryResult)
+        return ConfigCatClientSnapshot(
+            flagEvaluator: flagEvaluator,
+            settingsSnapshot: inMemorySettings.0,
+            cacheState: inMemorySettings.1,
+            defaultUser: defaultUser,
+            log: log
+        )
+    }
+    
+    func calcInMemorySettingsWithOverrides(inMemoryResult: InMemoryResult?) -> (SettingsResult, ClientCacheState) {
+        if let overrideDataSource = overrideDataSource, overrideDataSource.behaviour == .localOnly {
+            return (SettingsResult(settings: overrideDataSource.getOverrides(), fetchTime: .distantPast), ClientCacheState.hasLocalOverrideFlagDataOnly)
+        }
+        guard let inMemoryResult = inMemoryResult else {
+            return (.empty, ClientCacheState.noFlagData)
+        }
+        
+        let entry = inMemoryResult.entry
+        
+        if let overrideDataSource = overrideDataSource {
+            if overrideDataSource.behaviour == .localOverRemote {
+                return (SettingsResult(settings: entry.config.settings.merging(overrideDataSource.getOverrides()) { (_, new) in
+                    new
+                }, fetchTime: entry.fetchTime), inMemoryResult.cacheState)
+            }
+            if overrideDataSource.behaviour == .remoteOverLocal {
+                return (SettingsResult(settings: entry.config.settings.merging(overrideDataSource.getOverrides()) { (current, _) in
+                    current
+                }, fetchTime: entry.fetchTime), inMemoryResult.cacheState)
+            }
+        }
+        
+        return (SettingsResult(settings: entry.config.settings, fetchTime: entry.fetchTime), inMemoryResult.cacheState)
+    }
+}

--- a/Sources/ConfigCat/Utils.swift
+++ b/Sources/ConfigCat/Utils.swift
@@ -47,7 +47,7 @@ extension Equatable {
 }
 
 class Constants {
-    static let version: String = "11.2.0"
+    static let version: String = "11.3.0"
     static let configJsonName: String = "config_v6.json"
     static let configJsonCacheVersion: String = "v2"
     static let globalBaseUrl: String = "https://cdn-global.configcat.com"

--- a/Tests/ConfigCatTests/AutoPollingTests.swift
+++ b/Tests/ConfigCatTests/AutoPollingTests.swift
@@ -11,7 +11,7 @@ class AutoPollingTests: XCTestCase {
 
         let mode = PollingModes.autoPoll(autoPollIntervalInSeconds: 2)
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: .global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = expectation(description: "wait for settings")
         service.settings { settingsResult in
@@ -37,7 +37,7 @@ class AutoPollingTests: XCTestCase {
 
         let mode = PollingModes.autoPoll(autoPollIntervalInSeconds: 2)
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: .global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = expectation(description: "wait for settings")
         service.settings { settingsResult in
@@ -68,7 +68,7 @@ class AutoPollingTests: XCTestCase {
             called = true
         }
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: .global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: hooks, sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: hooks, sdkKey: "", offline: false)
 
         sleep(1)
 
@@ -90,7 +90,7 @@ class AutoPollingTests: XCTestCase {
 
         let mode = PollingModes.autoPoll(autoPollIntervalInSeconds: 1)
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: .global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         sleep(2)
 
@@ -113,7 +113,7 @@ class AutoPollingTests: XCTestCase {
         let start = Date()
         let mode = PollingModes.autoPoll(autoPollIntervalInSeconds: 60, maxInitWaitTimeInSeconds: 1)
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: .global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = expectation(description: "wait for settings")
         service.settings { settingsResult in
@@ -136,7 +136,7 @@ class AutoPollingTests: XCTestCase {
 
         let mode = PollingModes.autoPoll(autoPollIntervalInSeconds: 2)
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: .global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: mockCache, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: mockCache, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = expectation(description: "wait for settings")
         service.settings { settingsResult in
@@ -168,7 +168,7 @@ class AutoPollingTests: XCTestCase {
 
         let mode = PollingModes.autoPoll(autoPollIntervalInSeconds: 2)
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: .global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: FailingCache(), pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: FailingCache(), pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = expectation(description: "wait for settings")
         service.settings { settingsResult in
@@ -195,7 +195,7 @@ class AutoPollingTests: XCTestCase {
         let cache = SingleValueCache(initValue: initValue)
         let mode = PollingModes.autoPoll(autoPollIntervalInSeconds: 2)
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: .global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: cache, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: cache, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = expectation(description: "wait for settings")
         service.settings { settingsResult in
@@ -219,7 +219,7 @@ class AutoPollingTests: XCTestCase {
         let cache = SingleValueCache(initValue: initValue)
         let mode = PollingModes.autoPoll(autoPollIntervalInSeconds: 2)
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: .global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: cache, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: cache, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = expectation(description: "wait for settings")
         service.settings { settingsResult in
@@ -237,7 +237,7 @@ class AutoPollingTests: XCTestCase {
 
         let mode = PollingModes.autoPoll(autoPollIntervalInSeconds: 1)
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: .global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         Thread.sleep(forTimeInterval: 1.5)
 
@@ -262,7 +262,7 @@ class AutoPollingTests: XCTestCase {
 
         let mode = PollingModes.autoPoll(autoPollIntervalInSeconds: 1)
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: .global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: true)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: true)
 
         XCTAssertTrue(service.isOffline)
         Thread.sleep(forTimeInterval: 2)
@@ -286,7 +286,7 @@ class AutoPollingTests: XCTestCase {
         let start = Date()
         let mode = PollingModes.autoPoll(autoPollIntervalInSeconds: 60, maxInitWaitTimeInSeconds: 1)
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: .global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: cache, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: cache, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = expectation(description: "wait for settings")
         service.settings { settingsResult in
@@ -314,7 +314,7 @@ class AutoPollingTests: XCTestCase {
         let cache = SingleValueCache(initValue: initValue)
         let mode = PollingModes.autoPoll(autoPollIntervalInSeconds: 60, maxInitWaitTimeInSeconds: 1)
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: .global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: cache, pollingMode: mode, hooks: hooks, sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: cache, pollingMode: mode, hooks: hooks, sdkKey: "", offline: false)
 
         let expectation1 = expectation(description: "wait for settings")
         service.settings { settingsResult in
@@ -336,7 +336,7 @@ class AutoPollingTests: XCTestCase {
         let start = Date()
         let mode = PollingModes.autoPoll(autoPollIntervalInSeconds: 60, maxInitWaitTimeInSeconds: 1)
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: .global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: cache, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: cache, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = expectation(description: "wait for settings")
         service.settings { settingsResult in

--- a/Tests/ConfigCatTests/AutoPollingTests.swift
+++ b/Tests/ConfigCatTests/AutoPollingTests.swift
@@ -308,7 +308,7 @@ class AutoPollingTests: XCTestCase {
         let hooks = Hooks()
         hooks.addOnReady { state in
             ready = true
-            XCTAssertEqual(ClientReadyState.hasUpToDateFlagData, state)
+            XCTAssertEqual(ClientCacheState.hasUpToDateFlagData, state)
         }
         let initValue = String(format: testJsonFormat, "test").asEntryString()
         let cache = SingleValueCache(initValue: initValue)

--- a/Tests/ConfigCatTests/ConfigFetcherTests.swift
+++ b/Tests/ConfigCatTests/ConfigFetcherTests.swift
@@ -38,7 +38,7 @@ class ConfigFetcherTests: XCTestCase {
         let expectation = self.expectation(description: "wait for response")
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: "m", dataGovernance: DataGovernance.global)
         fetcher.fetch(eTag: "") { response in
-            XCTAssertEqual(.failure(message: "", isTransient: false), response)
+            XCTAssertEqual(.failure(message: "", errorCode: RefreshErrorCode.invalidSdkKey ,isTransient: false), response)
             XCTAssertNil(response.entry)
             expectation.fulfill()
         }

--- a/Tests/ConfigCatTests/Helpers.swift
+++ b/Tests/ConfigCatTests/Helpers.swift
@@ -4,7 +4,7 @@ import XCTest
 
 extension String {
     func toEntryFromConfigString() -> ConfigEntry {
-        return try! ConfigEntry.fromConfigJson(json: self, eTag: "", fetchTime: .distantPast).get()
+        return try! ConfigEntry.fromConfigJson(json: self, eTag: String.random(len: 5), fetchTime: .distantPast).get()
     }
 
     func asEntryString(date: Date = Date()) -> String {

--- a/Tests/ConfigCatTests/LazyLoadingTests.swift
+++ b/Tests/ConfigCatTests/LazyLoadingTests.swift
@@ -11,7 +11,7 @@ class LazyLoadingTests: XCTestCase {
 
         let mode = PollingModes.lazyLoad(cacheRefreshIntervalInSeconds: 2)
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: DataGovernance.global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = expectation(description: "wait for settings")
         service.settings { result in
@@ -47,7 +47,7 @@ class LazyLoadingTests: XCTestCase {
 
         let mode = PollingModes.lazyLoad(cacheRefreshIntervalInSeconds: 2)
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: DataGovernance.global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = expectation(description: "wait for settings")
         service.settings { result in
@@ -84,7 +84,7 @@ class LazyLoadingTests: XCTestCase {
 
         let mode = PollingModes.lazyLoad(cacheRefreshIntervalInSeconds: 2)
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: DataGovernance.global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: mockCache, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: mockCache, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = expectation(description: "wait for settings")
         service.settings { result in
@@ -117,7 +117,7 @@ class LazyLoadingTests: XCTestCase {
 
         let mode = PollingModes.lazyLoad(cacheRefreshIntervalInSeconds: 2)
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: DataGovernance.global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: FailingCache(), pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: FailingCache(), pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = expectation(description: "wait for settings")
         service.settings { result in
@@ -145,7 +145,7 @@ class LazyLoadingTests: XCTestCase {
         let cache = SingleValueCache(initValue: initValue)
         let mode = PollingModes.lazyLoad(cacheRefreshIntervalInSeconds: 1)
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: .global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: cache, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: cache, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = expectation(description: "wait for settings")
         service.settings { settingsResult in
@@ -190,7 +190,7 @@ class LazyLoadingTests: XCTestCase {
         let cache = SingleValueCache(initValue: initValue)
         let mode = PollingModes.lazyLoad(cacheRefreshIntervalInSeconds: 1)
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: .global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: cache, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: cache, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = expectation(description: "wait for settings")
         service.settings { settingsResult in
@@ -233,7 +233,7 @@ class LazyLoadingTests: XCTestCase {
 
         let mode = PollingModes.lazyLoad(cacheRefreshIntervalInSeconds: 1)
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: .global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = expectation(description: "wait for settings")
         service.settings { settingsResult in
@@ -274,7 +274,7 @@ class LazyLoadingTests: XCTestCase {
 
         let mode = PollingModes.lazyLoad(cacheRefreshIntervalInSeconds: 1)
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: .global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: true)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: true)
 
         let expectation1 = expectation(description: "wait for settings")
         service.settings { settingsResult in

--- a/Tests/ConfigCatTests/LocalTests.swift
+++ b/Tests/ConfigCatTests/LocalTests.swift
@@ -62,4 +62,71 @@ class LocalTests: XCTestCase {
         }
         wait(for: [expectation], timeout: 5)
     }
+    
+    #if compiler(>=5.5) && canImport(_Concurrency)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    func testDictionarySnapshot() async throws {
+        let dictionary: [String: Any] = [
+            "enabledFeature": true,
+            "disabledFeature": false,
+            "intSetting": 5,
+            "doubleSetting": 3.14,
+            "stringSetting": "test"
+        ]
+        let options = ConfigCatOptions.default
+        options.flagOverrides = LocalDictionaryDataSource(source: dictionary, behaviour: .localOnly)
+        let client = ConfigCatClient.get(sdkKey: "testKey", options: options)
+        
+        await client.waitForReady()
+        
+        let snapshot = client.snapshot()
+        let values = snapshot.getAllValues()
+        
+        XCTAssertTrue(values["enabledFeature"] as? Bool ?? false)
+        XCTAssertFalse(values["disabledFeature"] as? Bool ?? true)
+        XCTAssertEqual(5, values["intSetting"] as? Int ?? 0)
+        XCTAssertEqual(3.14, values["doubleSetting"] as? Double ?? 0.0)
+        XCTAssertEqual("test", values["stringSetting"] as? String ?? "")
+    }
+
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    func testLocalOverRemoteSnapshot() async throws {
+        let engine = MockEngine()
+        engine.enqueueResponse(response: Response(body: String(format: testJsonFormat, "false"), statusCode: 200))
+
+        let dictionary: [String: Any] = [
+            "fakeKey": true,
+            "nonexisting": true
+        ]
+        let client = ConfigCatClient(sdkKey: randomSdkKey(), pollingMode: PollingModes.autoPoll(), logger: NoLogger(), httpEngine: engine, hooks: Hooks(), flagOverrides: LocalDictionaryDataSource(source: dictionary, behaviour: .localOverRemote))
+        
+        await client.waitForReady()
+        
+        let snapshot = client.snapshot()
+        let values = snapshot.getAllValues()
+        
+        XCTAssertTrue(values["fakeKey"] as? Bool ?? false)
+        XCTAssertTrue(values["nonexisting"] as? Bool ?? false)
+    }
+
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    func testRemoteOverLocalSnapshot() async throws {
+        let engine = MockEngine()
+        engine.enqueueResponse(response: Response(body: String(format: testJsonFormat, "false"), statusCode: 200))
+
+        let dictionary: [String: Any] = [
+            "fakeKey": true,
+            "nonexisting": true
+        ]
+        let client = ConfigCatClient(sdkKey: randomSdkKey(), pollingMode: PollingModes.autoPoll(), logger: NoLogger(), httpEngine: engine, hooks: Hooks(), flagOverrides: LocalDictionaryDataSource(source: dictionary, behaviour: .remoteOverLocal))
+        
+        await client.waitForReady()
+        
+        let snapshot = client.snapshot()
+        let values = snapshot.getAllValues()
+        
+        XCTAssertFalse(values["fakeKey"] as? Bool ?? true)
+        XCTAssertTrue(values["nonexisting"] as? Bool ?? false)
+    }
+    #endif
 }

--- a/Tests/ConfigCatTests/LocalTests.swift
+++ b/Tests/ConfigCatTests/LocalTests.swift
@@ -80,8 +80,11 @@ class LocalTests: XCTestCase {
         await client.waitForReady()
         
         let snapshot = client.snapshot()
-        let values = snapshot.getAllValues()
         
+        var values = [String: Any]()
+        for key in snapshot.getAllKeys() {
+            values[key] = snapshot.getAnyValue(for: key, defaultValue: {}, user: nil)
+        }
         XCTAssertTrue(values["enabledFeature"] as? Bool ?? false)
         XCTAssertFalse(values["disabledFeature"] as? Bool ?? true)
         XCTAssertEqual(5, values["intSetting"] as? Int ?? 0)
@@ -103,8 +106,11 @@ class LocalTests: XCTestCase {
         await client.waitForReady()
         
         let snapshot = client.snapshot()
-        let values = snapshot.getAllValues()
         
+        var values = [String: Any]()
+        for key in snapshot.getAllKeys() {
+            values[key] = snapshot.getAnyValue(for: key, defaultValue: {}, user: nil)
+        }
         XCTAssertTrue(values["fakeKey"] as? Bool ?? false)
         XCTAssertTrue(values["nonexisting"] as? Bool ?? false)
     }
@@ -123,8 +129,11 @@ class LocalTests: XCTestCase {
         await client.waitForReady()
         
         let snapshot = client.snapshot()
-        let values = snapshot.getAllValues()
         
+        var values = [String: Any]()
+        for key in snapshot.getAllKeys() {
+            values[key] = snapshot.getAnyValue(for: key, defaultValue: {}, user: nil)
+        }
         XCTAssertFalse(values["fakeKey"] as? Bool ?? true)
         XCTAssertTrue(values["nonexisting"] as? Bool ?? false)
     }

--- a/Tests/ConfigCatTests/ManualPollingTests.swift
+++ b/Tests/ConfigCatTests/ManualPollingTests.swift
@@ -11,7 +11,7 @@ class ManualPollingTests: XCTestCase {
 
         let mode = PollingModes.manualPoll()
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: DataGovernance.global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = self.expectation(description: "wait for response")
         service.refresh { result in
@@ -53,7 +53,7 @@ class ManualPollingTests: XCTestCase {
 
         let mode = PollingModes.manualPoll()
         let fetcher = ConfigFetcher(httpEngine: engine, logger: logger, sdkKey: "", mode: mode.identifier, dataGovernance: DataGovernance.global)
-        let service = ConfigService(log: logger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: hooks, sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: logger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: hooks, sdkKey: "", offline: false)
 
         let expectation1 = self.expectation(description: "wait for response")
         service.refresh { result in
@@ -90,7 +90,7 @@ class ManualPollingTests: XCTestCase {
 
         let mode = PollingModes.manualPoll()
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: DataGovernance.global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = self.expectation(description: "wait for response")
         service.refresh { result in
@@ -108,7 +108,7 @@ class ManualPollingTests: XCTestCase {
 
         let mode = PollingModes.manualPoll()
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: DataGovernance.global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = self.expectation(description: "wait for response")
         service.refresh { result in
@@ -126,7 +126,7 @@ class ManualPollingTests: XCTestCase {
 
         let mode = PollingModes.manualPoll()
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: DataGovernance.global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = self.expectation(description: "wait for response")
         service.refresh { result in
@@ -144,7 +144,7 @@ class ManualPollingTests: XCTestCase {
 
         let mode = PollingModes.manualPoll()
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: DataGovernance.global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = self.expectation(description: "wait for response")
         service.refresh { result in
@@ -164,7 +164,7 @@ class ManualPollingTests: XCTestCase {
 
         let mode = PollingModes.manualPoll()
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: DataGovernance.global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: mockCache, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: mockCache, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = self.expectation(description: "wait for response")
         service.refresh { result in
@@ -202,7 +202,7 @@ class ManualPollingTests: XCTestCase {
 
         let mode = PollingModes.manualPoll()
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: DataGovernance.global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: FailingCache(), pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: FailingCache(), pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = self.expectation(description: "wait for response")
         service.refresh { result in
@@ -235,7 +235,7 @@ class ManualPollingTests: XCTestCase {
 
         let mode = PollingModes.manualPoll()
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: DataGovernance.global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: FailingCache(), pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: FailingCache(), pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = self.expectation(description: "wait for response")
         service.settings { settingsResult in
@@ -253,7 +253,7 @@ class ManualPollingTests: XCTestCase {
 
         let mode = PollingModes.manualPoll()
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: DataGovernance.global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: false)
 
         let expectation1 = self.expectation(description: "wait for response")
         service.refresh { result in
@@ -298,7 +298,7 @@ class ManualPollingTests: XCTestCase {
 
         let mode = PollingModes.manualPoll()
         let fetcher = ConfigFetcher(httpEngine: engine, logger: InternalLogger.noLogger, sdkKey: "", mode: mode.identifier, dataGovernance: DataGovernance.global)
-        let service = ConfigService(log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: true)
+        let service = ConfigService(snapshotBuilder: EmptySnapshotBuilder(), log: InternalLogger.noLogger, fetcher: fetcher, cache: nil, pollingMode: mode, hooks: Hooks(), sdkKey: "", offline: true)
 
         let expectation1 = self.expectation(description: "wait for response")
         service.refresh { result in

--- a/Tests/ConfigCatTests/Mock.swift
+++ b/Tests/ConfigCatTests/Mock.swift
@@ -84,3 +84,11 @@ class SingleValueCache: NSObject, ConfigCache {
         self.value = value
     }
 }
+
+class EmptySnapshotBuilder: SnapshotBuilderProtocol {
+    func buildSnapshot(inMemoryResult: InMemoryResult?) -> ConfigCatClientSnapshot {
+        ConfigCatClientSnapshot(flagEvaluator: FlagEvaluator(log: InternalLogger.noLogger, evaluator: RolloutEvaluator(logger: InternalLogger.noLogger), hooks: Hooks()), settingsSnapshot: SettingsResult.empty, cacheState: .noFlagData, defaultUser: nil, log: InternalLogger.noLogger)
+    }
+    
+    var defaultUser: ConfigCatUser?
+}

--- a/Tests/ConfigCatTests/SnapshotTests.swift
+++ b/Tests/ConfigCatTests/SnapshotTests.swift
@@ -105,5 +105,33 @@ class SnapshotTests: XCTestCase {
             client.snapshot().cacheState == .hasUpToDateFlagData
         }
     }
+    
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    func testGetAllKeysEmpty() async {
+        let engine = MockEngine()
+        engine.enqueueResponse(response: Response(body: "", statusCode: 200))
+
+        let client = ConfigCatClient(sdkKey: randomSdkKey(), pollingMode: PollingModes.autoPoll(), logger: NoLogger(), httpEngine: engine)
+        
+        await client.waitForReady()
+        let snapshot = client.snapshot()
+        
+        XCTAssertEqual([], snapshot.getAllKeys())
+    }
+    
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    func testInvalidInput() async {
+        let engine = MockEngine()
+        engine.enqueueResponse(response: Response(body: testJsonMultiple, statusCode: 200))
+
+        let client = ConfigCatClient(sdkKey: randomSdkKey(), pollingMode: PollingModes.autoPoll(), logger: NoLogger(), httpEngine: engine)
+        
+        await client.waitForReady()
+        
+        let snapshot = client.snapshot()
+        let details = snapshot.getValueDetails(for: "key", defaultValue: NSColor())
+        
+        XCTAssertEqual(EvaluationErrorCode.invalidUserInput, details.errorCode)
+    }
     #endif
 }

--- a/Tests/ConfigCatTests/SnapshotTests.swift
+++ b/Tests/ConfigCatTests/SnapshotTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import ConfigCat
 
 class SnapshotTests: XCTestCase {
+    let testJsonFormat = #"{ "f": { "fakeKey": { "t": 1, "v": { "s": "%@" } } } }"#
     let testJsonMultiple = #"{"f":{"key1":{"t":0,"v":{"b":true},"i":"fakeId1"},"key2":{"t":0,"r":[{"c":[{"u":{"a":"Email","c":2,"l":["@example.com"]}}],"s":{"v":{"b":true},"i":"9f21c24c"}}],"v":{"b":false},"i":"fakeId2"}}}"#
     let user = ConfigCatUser(identifier: "id", email: "test@example.com")
 
@@ -132,6 +133,208 @@ class SnapshotTests: XCTestCase {
         let details = snapshot.getValueDetails(for: "key", defaultValue: UInt8())
         
         XCTAssertEqual(EvaluationErrorCode.invalidUserInput, details.errorCode)
+    }
+    
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    func testHookSnapshot() async {
+        let engine = MockEngine()
+        engine.enqueueResponse(response: Response(body: testJsonMultiple, statusCode: 200))
+
+        let hooks = Hooks()
+        var called = false
+        hooks.addOnConfigChangedWithSnapshot { snapshot in
+            XCTAssertEqual(ClientCacheState.hasUpToDateFlagData, snapshot.cacheState)
+            let value = snapshot.getValue(for: "key1", defaultValue: false)
+            XCTAssertTrue(value)
+            called = true
+        }
+        
+        let client = ConfigCatClient(sdkKey: randomSdkKey(), pollingMode: PollingModes.autoPoll(), logger: NoLogger(), httpEngine: engine, hooks: hooks)
+        let state = await client.waitForReady()
+        XCTAssertEqual(ClientCacheState.hasUpToDateFlagData, state)
+        
+        waitFor {
+            called
+        }
+    }
+    
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    func testReadyHookSnapshot() async {
+        let engine = MockEngine()
+        engine.enqueueResponse(response: Response(body: testJsonMultiple, statusCode: 200))
+
+        let hooks = Hooks()
+        var called = false
+        hooks.addOnReadyWithSnapshot { snapshot in
+            XCTAssertEqual(ClientCacheState.hasUpToDateFlagData, snapshot.cacheState)
+            let value = snapshot.getValue(for: "key1", defaultValue: false)
+            XCTAssertTrue(value)
+            called = true
+        }
+        
+        let client = ConfigCatClient(sdkKey: randomSdkKey(), pollingMode: PollingModes.autoPoll(), logger: NoLogger(), httpEngine: engine, hooks: hooks)
+        let state = await client.waitForReady()
+        XCTAssertEqual(ClientCacheState.hasUpToDateFlagData, state)
+        
+        waitFor {
+            called
+        }
+    }
+    
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    func testHookSnapshotCache() async {
+        let engine = MockEngine()
+        engine.enqueueResponse(response: Response(body: "", statusCode: 500))
+
+        let initValue = String(format: testJsonFormat, "test1").asEntryString(date: Date())
+        let cache = SingleValueCache(initValue: initValue)
+        
+        let hooks = Hooks()
+        var called = false
+        hooks.addOnConfigChangedWithSnapshot { snapshot in
+            XCTAssertEqual(ClientCacheState.hasUpToDateFlagData, snapshot.cacheState)
+            let value = snapshot.getValue(for: "fakeKey", defaultValue: "")
+            XCTAssertEqual("test1", value)
+            called = true
+        }
+        
+        let client = ConfigCatClient(sdkKey: randomSdkKey(), pollingMode: PollingModes.autoPoll(), logger: NoLogger(), httpEngine: engine, hooks: hooks, configCache: cache)
+        let state = await client.waitForReady()
+        XCTAssertEqual(ClientCacheState.hasUpToDateFlagData, state)
+        
+        waitFor {
+            called
+        }
+    }
+    
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    func testReadyHookSnapshotCache() async {
+        let engine = MockEngine()
+        engine.enqueueResponse(response: Response(body: "", statusCode: 500))
+
+        let initValue = String(format: testJsonFormat, "test1").asEntryString(date: Date())
+        let cache = SingleValueCache(initValue: initValue)
+        
+        let hooks = Hooks()
+        var called = false
+        hooks.addOnReadyWithSnapshot { snapshot in
+            XCTAssertEqual(ClientCacheState.hasUpToDateFlagData, snapshot.cacheState)
+            let value = snapshot.getValue(for: "fakeKey", defaultValue: "")
+            XCTAssertEqual("test1", value)
+            called = true
+        }
+        
+        let client = ConfigCatClient(sdkKey: randomSdkKey(), pollingMode: PollingModes.autoPoll(), logger: NoLogger(), httpEngine: engine, hooks: hooks, configCache: cache)
+        let state = await client.waitForReady()
+        XCTAssertEqual(ClientCacheState.hasUpToDateFlagData, state)
+        
+        waitFor {
+            called
+        }
+    }
+    
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    func testHookSnapshotCacheExpired() async {
+        let engine = MockEngine()
+        engine.enqueueResponse(response: Response(body: "", statusCode: 500))
+
+        let initValue = String(format: testJsonFormat, "test1").asEntryString(date: Date.distantPast)
+        let cache = SingleValueCache(initValue: initValue)
+        
+        let hooks = Hooks()
+        var called = false
+        hooks.addOnConfigChangedWithSnapshot { snapshot in
+            XCTAssertEqual(ClientCacheState.hasCachedFlagDataOnly, snapshot.cacheState)
+            let value = snapshot.getValue(for: "fakeKey", defaultValue: "")
+            XCTAssertEqual("test1", value)
+            called = true
+        }
+        
+        let client = ConfigCatClient(sdkKey: randomSdkKey(), pollingMode: PollingModes.autoPoll(), logger: NoLogger(), httpEngine: engine, hooks: hooks, configCache: cache)
+        let state = await client.waitForReady()
+        XCTAssertEqual(ClientCacheState.hasCachedFlagDataOnly, state)
+        
+        waitFor {
+            called
+        }
+    }
+    
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    func testReadyHookSnapshotCacheExpired() async {
+        let engine = MockEngine()
+        engine.enqueueResponse(response: Response(body: "", statusCode: 500))
+
+        let initValue = String(format: testJsonFormat, "test1").asEntryString(date: Date.distantPast)
+        let cache = SingleValueCache(initValue: initValue)
+        
+        let hooks = Hooks()
+        var called = false
+        hooks.addOnReadyWithSnapshot { snapshot in
+            XCTAssertEqual(ClientCacheState.hasCachedFlagDataOnly, snapshot.cacheState)
+            let value = snapshot.getValue(for: "fakeKey", defaultValue: "")
+            XCTAssertEqual("test1", value)
+            called = true
+        }
+        
+        let client = ConfigCatClient(sdkKey: randomSdkKey(), pollingMode: PollingModes.autoPoll(), logger: NoLogger(), httpEngine: engine, hooks: hooks, configCache: cache)
+        let state = await client.waitForReady()
+        XCTAssertEqual(ClientCacheState.hasCachedFlagDataOnly, state)
+        
+        waitFor {
+            called
+        }
+    }
+    
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    func testHookSnapshotManual() async {
+        let engine = MockEngine()
+        engine.enqueueResponse(response: Response(body: "", statusCode: 500))
+
+        let initValue = String(format: testJsonFormat, "test1").asEntryString(date: Date.distantPast)
+        let cache = SingleValueCache(initValue: initValue)
+        
+        let hooks = Hooks()
+        var called = false
+        hooks.addOnConfigChangedWithSnapshot { snapshot in
+            XCTAssertEqual(ClientCacheState.hasCachedFlagDataOnly, snapshot.cacheState)
+            let value = snapshot.getValue(for: "fakeKey", defaultValue: "")
+            XCTAssertEqual("test1", value)
+            called = true
+        }
+        
+        let client = ConfigCatClient(sdkKey: randomSdkKey(), pollingMode: PollingModes.manualPoll(), logger: NoLogger(), httpEngine: engine, hooks: hooks, configCache: cache)
+        let state = await client.waitForReady()
+        XCTAssertEqual(ClientCacheState.hasCachedFlagDataOnly, state)
+        
+        waitFor {
+            called
+        }
+    }
+    
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+    func testReadyHookSnapshotManual() async {
+        let engine = MockEngine()
+        engine.enqueueResponse(response: Response(body: "", statusCode: 500))
+
+        let initValue = String(format: testJsonFormat, "test1").asEntryString(date: Date.distantPast)
+        let cache = SingleValueCache(initValue: initValue)
+        
+        let hooks = Hooks()
+        var called = false
+        hooks.addOnReadyWithSnapshot { snapshot in
+            XCTAssertEqual(ClientCacheState.hasCachedFlagDataOnly, snapshot.cacheState)
+            let value = snapshot.getValue(for: "fakeKey", defaultValue: "")
+            XCTAssertEqual("test1", value)
+            called = true
+        }
+        
+        let client = ConfigCatClient(sdkKey: randomSdkKey(), pollingMode: PollingModes.manualPoll(), logger: NoLogger(), httpEngine: engine, hooks: hooks, configCache: cache)
+        let state = await client.waitForReady()
+        XCTAssertEqual(ClientCacheState.hasCachedFlagDataOnly, state)
+        
+        waitFor {
+            called
+        }
     }
     #endif
 }

--- a/Tests/ConfigCatTests/SnapshotTests.swift
+++ b/Tests/ConfigCatTests/SnapshotTests.swift
@@ -129,7 +129,7 @@ class SnapshotTests: XCTestCase {
         await client.waitForReady()
         
         let snapshot = client.snapshot()
-        let details = snapshot.getValueDetails(for: "key", defaultValue: NSColor())
+        let details = snapshot.getValueDetails(for: "key", defaultValue: UInt8())
         
         XCTAssertEqual(EvaluationErrorCode.invalidUserInput, details.errorCode)
     }

--- a/Tests/ConfigCatTests/SnapshotTests.swift
+++ b/Tests/ConfigCatTests/SnapshotTests.swift
@@ -12,9 +12,9 @@ class SnapshotTests: XCTestCase {
         
         let client = ConfigCatClient(sdkKey: randomSdkKey(), pollingMode: PollingModes.autoPoll(), logger: NoLogger(), httpEngine: engine)
         let expectation = self.expectation(description: "wait for ready")
-        client.hooks.addOnReady { _ in
+        client.hooks.addOnReady(handler: { _ in
             expectation.fulfill()
-        }
+        })
         wait(for: [expectation], timeout: 5)
         
         let snapshot = client.snapshot()
@@ -30,9 +30,9 @@ class SnapshotTests: XCTestCase {
        
         let client = ConfigCatClient(sdkKey: randomSdkKey(), pollingMode: PollingModes.autoPoll(), logger: NoLogger(), httpEngine: engine)
         let expectation = self.expectation(description: "wait for ready")
-        client.hooks.addOnReady { _ in
+        client.hooks.addOnReady(handler: { _ in
             expectation.fulfill()
-        }
+        })
         wait(for: [expectation], timeout: 5)
         
         let snapshot = client.snapshot()
@@ -47,9 +47,9 @@ class SnapshotTests: XCTestCase {
 
         let client = ConfigCatClient(sdkKey: randomSdkKey(), pollingMode: PollingModes.autoPoll(), logger: NoLogger(), httpEngine: engine)
         let expectation = self.expectation(description: "wait for ready")
-        client.hooks.addOnReady { _ in
+        client.hooks.addOnReady(handler: { _ in
             expectation.fulfill()
-        }
+        })
         wait(for: [expectation], timeout: 5)
         
         let snapshot = client.snapshot()
@@ -142,7 +142,7 @@ class SnapshotTests: XCTestCase {
 
         let hooks = Hooks()
         var called = false
-        hooks.addOnConfigChangedWithSnapshot { snapshot in
+        hooks.addOnConfigChanged { _, snapshot in
             XCTAssertEqual(ClientCacheState.hasUpToDateFlagData, snapshot.cacheState)
             let value = snapshot.getValue(for: "key1", defaultValue: false)
             XCTAssertTrue(value)
@@ -165,7 +165,8 @@ class SnapshotTests: XCTestCase {
 
         let hooks = Hooks()
         var called = false
-        hooks.addOnReadyWithSnapshot { snapshot in
+        
+        hooks.addOnReady { snapshot in
             XCTAssertEqual(ClientCacheState.hasUpToDateFlagData, snapshot.cacheState)
             let value = snapshot.getValue(for: "key1", defaultValue: false)
             XCTAssertTrue(value)
@@ -191,7 +192,7 @@ class SnapshotTests: XCTestCase {
         
         let hooks = Hooks()
         var called = false
-        hooks.addOnConfigChangedWithSnapshot { snapshot in
+        hooks.addOnConfigChanged { _, snapshot in
             XCTAssertEqual(ClientCacheState.hasUpToDateFlagData, snapshot.cacheState)
             let value = snapshot.getValue(for: "fakeKey", defaultValue: "")
             XCTAssertEqual("test1", value)
@@ -217,7 +218,7 @@ class SnapshotTests: XCTestCase {
         
         let hooks = Hooks()
         var called = false
-        hooks.addOnReadyWithSnapshot { snapshot in
+        hooks.addOnReady { snapshot in
             XCTAssertEqual(ClientCacheState.hasUpToDateFlagData, snapshot.cacheState)
             let value = snapshot.getValue(for: "fakeKey", defaultValue: "")
             XCTAssertEqual("test1", value)
@@ -243,7 +244,7 @@ class SnapshotTests: XCTestCase {
         
         let hooks = Hooks()
         var called = false
-        hooks.addOnConfigChangedWithSnapshot { snapshot in
+        hooks.addOnConfigChanged { _, snapshot in
             XCTAssertEqual(ClientCacheState.hasCachedFlagDataOnly, snapshot.cacheState)
             let value = snapshot.getValue(for: "fakeKey", defaultValue: "")
             XCTAssertEqual("test1", value)
@@ -269,7 +270,7 @@ class SnapshotTests: XCTestCase {
         
         let hooks = Hooks()
         var called = false
-        hooks.addOnReadyWithSnapshot { snapshot in
+        hooks.addOnReady { snapshot in
             XCTAssertEqual(ClientCacheState.hasCachedFlagDataOnly, snapshot.cacheState)
             let value = snapshot.getValue(for: "fakeKey", defaultValue: "")
             XCTAssertEqual("test1", value)
@@ -295,7 +296,7 @@ class SnapshotTests: XCTestCase {
         
         let hooks = Hooks()
         var called = false
-        hooks.addOnConfigChangedWithSnapshot { snapshot in
+        hooks.addOnConfigChanged { _, snapshot in
             XCTAssertEqual(ClientCacheState.hasCachedFlagDataOnly, snapshot.cacheState)
             let value = snapshot.getValue(for: "fakeKey", defaultValue: "")
             XCTAssertEqual("test1", value)
@@ -321,7 +322,7 @@ class SnapshotTests: XCTestCase {
         
         let hooks = Hooks()
         var called = false
-        hooks.addOnReadyWithSnapshot { snapshot in
+        hooks.addOnReady { snapshot in
             XCTAssertEqual(ClientCacheState.hasCachedFlagDataOnly, snapshot.cacheState)
             let value = snapshot.getValue(for: "fakeKey", defaultValue: "")
             XCTAssertEqual("test1", value)


### PR DESCRIPTION
### Describe the purpose of your pull request
This PR contains the following:

- When an external cache is configured, the SDK continues to sync with it in offline mode.
- Introduce new error codes for better error handling on `EvaluationDetails` and `RefreshResults`.

#### Minor breaking changes
Some components (usually not directly referenced by type) were renamed:
- `ConfigCatSnapshot` -> `ConfigCatClientSnapshot`
- `ClientReadyState` -> `ClientCacheState`

### Related issues (only if applicable)
- https://trello.com/c/XZdBOLY1
- https://trello.com/c/mU63054x
- https://trello.com/c/K91bDeht

### Requirement checklist (only if applicable)
- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
