### PR TITLE
Make waitForReady work similar to other ConfigCat SDKs

### DIFF
--- a/Sources/ConfigCat/ConfigCatClient.swift
+++ b/Sources/ConfigCat/ConfigCatClient.swift
@@ -380,11 +380,7 @@ public final class ConfigCatClient: NSObject, ConfigCatClientProtocol {
     public func waitForReady() async -> ClientCacheState {
         // withCheckedContinuation sometimes crashes on iOS 18.0. See https://github.com/RevenueCat/purchases-ios/pull/4286
         await withUnsafeContinuation { continuation in
-            guard let configService = self.configService else {
-                continuation.resume(returning: .hasLocalOverrideFlagDataOnly)
-                return
-            }
-            configService.onReady { state in
+            hooks.addOnReady { state in
                 continuation.resume(returning: state)
             }
         }

--- a/Sources/ConfigCat/ConfigService.swift
+++ b/Sources/ConfigCat/ConfigService.swift
@@ -210,17 +210,7 @@ class ConfigService {
             return offline
         }
     }
-    
-    func onReady(completion: @escaping (ClientCacheState) -> Void) {
-        mutex.lock()
-        defer { mutex.unlock() }
-        if initialized {
-            completion(determineReadyState())
-        } else {
-            hooks.addOnReady(handler: completion)
-        }
-    }
-    
+
     var inMemory: InMemoryResult {
         get {
             mutex.lock()


### PR DESCRIPTION
### Describe the purpose of your pull request
- Consecutive `waitForReady()` calls now return with the original client state that was first calculated upon client initialization.

### Requirement checklist (only if applicable)
- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
